### PR TITLE
[feat #14] Security Context 유저 저장

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/model/PrincipalUser.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/model/PrincipalUser.kt
@@ -1,0 +1,36 @@
+package com.pokit.auth.model
+
+import com.pokit.user.model.Role
+import com.pokit.user.model.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+data class PrincipalUser(
+    val id: Long,
+    val email: String,
+    val role: Role,
+) : UserDetails {
+    companion object {
+        fun of(user: User) =
+            PrincipalUser(
+                id = user.id,
+                email = user.email,
+                role = user.role,
+            )
+    }
+
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority> {
+        return mutableListOf(SimpleGrantedAuthority(role.description))
+    }
+
+    override fun getPassword(): String? {
+        return null
+    }
+
+    override fun getUsername(): String {
+        return email
+    }
+}
+
+fun PrincipalUser.toDomain() = User(id = this.id, email = this.email, role = this.role)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
@@ -5,6 +5,7 @@ import com.pokit.out.persistence.user.persist.UserRepository
 import com.pokit.out.persistence.user.persist.toDomain
 import com.pokit.user.model.User
 import com.pokit.user.port.out.UserPort
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -20,5 +21,10 @@ class UserAdapter(
     override fun loadByEmail(email: String): User? {
         val userJpaEntity = userRepository.findByEmail(email)
         return userJpaEntity?.toDomain()
+    }
+
+    override fun loadById(id: Long): User? {
+        val userEntity = userRepository.findByIdOrNull(id)
+        return userEntity?.toDomain()
     }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
@@ -18,13 +18,9 @@ class UserAdapter(
         return savedUser.toDomain()
     }
 
-    override fun loadByEmail(email: String): User? {
-        val userJpaEntity = userRepository.findByEmail(email)
-        return userJpaEntity?.toDomain()
-    }
+    override fun loadByEmail(email: String) = userRepository.findByEmail(email)
+        ?.run { toDomain() }
 
-    override fun loadById(id: Long): User? {
-        val userEntity = userRepository.findByIdOrNull(id)
-        return userEntity?.toDomain()
-    }
+    override fun loadById(id: Long) = userRepository.findByIdOrNull(id)
+        ?.run { toDomain() }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
@@ -28,5 +28,3 @@ class UserEntity(
 }
 
 fun UserEntity.toDomain() = User(id = this.id, email = this.email, role = this.role)
-
-fun UserEntity.toPrincipalUser() = null // Security Context에 담을 user

--- a/adapters/out-web/src/main/kotlin/com/pokit/auth/common/config/FirebaseConfig.kt
+++ b/adapters/out-web/src/main/kotlin/com/pokit/auth/common/config/FirebaseConfig.kt
@@ -15,9 +15,10 @@ class FirebaseConfig {
         val resource = ClassPathResource("google-services.json")
         val serviceAccount = resource.inputStream
 
-        val options = FirebaseOptions.builder()
-            .setCredentials(GoogleCredentials.fromStream(serviceAccount))
-            .build()
+        val options =
+            FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build()
 
         return FirebaseApp.initializeApp(options)
     }

--- a/adapters/out-web/src/main/kotlin/com/pokit/auth/common/dto/ApplePublicKeys.kt
+++ b/adapters/out-web/src/main/kotlin/com/pokit/auth/common/dto/ApplePublicKeys.kt
@@ -3,7 +3,10 @@ package com.pokit.auth.common.dto
 data class ApplePublicKeys(
     val keys: List<ApplePublicKey>,
 ) {
-    fun getMatchedKey(alg: String, kid: String): ApplePublicKey? {
+    fun getMatchedKey(
+        alg: String,
+        kid: String,
+    ): ApplePublicKey? {
         return keys.firstOrNull { key ->
             key.alg == alg && key.kid == kid
         }

--- a/adapters/out-web/src/main/kotlin/com/pokit/auth/common/support/AppleKeyGenerator.kt
+++ b/adapters/out-web/src/main/kotlin/com/pokit/auth/common/support/AppleKeyGenerator.kt
@@ -13,11 +13,14 @@ import java.util.Base64
 
 @Component
 class AppleKeyGenerator {
-    fun generatePublicKey(headers: Map<String, String>, publicKeys: ApplePublicKeys): PublicKey {
+    fun generatePublicKey(
+        headers: Map<String, String>,
+        publicKeys: ApplePublicKeys,
+    ): PublicKey {
         val alg = headers["alg"]
-            ?: throw ClientValidationException(AuthErrorCode.INVALID_ID_TOKEN)
+                ?: throw ClientValidationException(AuthErrorCode.INVALID_ID_TOKEN)
         val kid = headers["kid"]
-            ?: throw ClientValidationException(AuthErrorCode.INVALID_ID_TOKEN)
+                ?: throw ClientValidationException(AuthErrorCode.INVALID_ID_TOKEN)
         val publicKey = publicKeys.getMatchedKey(alg, kid) ?: throw ClientValidationException(AuthErrorCode.INVALID_ID_TOKEN)
 
         return getPublicKey(publicKey)

--- a/adapters/out-web/src/main/kotlin/com/pokit/auth/common/support/AppleTokenParser.kt
+++ b/adapters/out-web/src/main/kotlin/com/pokit/auth/common/support/AppleTokenParser.kt
@@ -21,7 +21,10 @@ class AppleTokenParser(
         return objectMapper.readValue(decodedHeader, typeReference)
     }
 
-    fun parseClaims(idToken: String, publicKey: PublicKey): Claims {
+    fun parseClaims(
+        idToken: String,
+        publicKey: PublicKey,
+    ): Claims {
         return Jwts.parser()
             .verifyWith(publicKey)
             .build()

--- a/adapters/out-web/src/main/kotlin/com/pokit/auth/impl/AppleApiAdapter.kt
+++ b/adapters/out-web/src/main/kotlin/com/pokit/auth/impl/AppleApiAdapter.kt
@@ -9,13 +9,12 @@ import org.springframework.stereotype.Component
 import org.springframework.web.client.RestTemplate
 import org.springframework.web.util.UriComponentsBuilder
 
-
 @Component
 class AppleApiAdapter(
     private val restTemplate: RestTemplate,
     private val appleKeyGenerator: AppleKeyGenerator,
-    private val appleTokenParser: AppleTokenParser
-) : AppleApiClient{
+    private val appleTokenParser: AppleTokenParser,
+) : AppleApiClient {
     override fun getUserInfo(idToken: String): UserInfo {
         val claims = decodeAndVerifyIdToken(idToken) // id token을 통해 사용자 정보 추출
         val email = claims["email"] as String
@@ -26,16 +25,18 @@ class AppleApiAdapter(
     // 애플에게 공개 키 요청 후 공개키로 idToken 내 고객 정보 추출
     private fun decodeAndVerifyIdToken(idToken: String): Map<String, Any> {
         val appleKeyUrl = "https://appleid.apple.com/auth/keys"
-        val url = UriComponentsBuilder
-            .fromUriString(appleKeyUrl)
-            .encode()
-            .build()
-            .toUri()
+        val url =
+            UriComponentsBuilder
+                .fromUriString(appleKeyUrl)
+                .encode()
+                .build()
+                .toUri()
 
-        val publicKeys = restTemplate.getForObject(
-            url,
-            ApplePublicKeys::class.java
-        )
+        val publicKeys =
+            restTemplate.getForObject(
+                url,
+                ApplePublicKeys::class.java,
+            )
 
         val header = appleTokenParser.parseHeader(idToken)
         val publicKey = appleKeyGenerator.generatePublicKey(header, publicKeys)

--- a/adapters/out-web/src/main/kotlin/com/pokit/auth/impl/GoogleApiAdapter.kt
+++ b/adapters/out-web/src/main/kotlin/com/pokit/auth/impl/GoogleApiAdapter.kt
@@ -7,8 +7,8 @@ import org.springframework.stereotype.Component
 
 @Component
 class GoogleApiAdapter(
-    private val firebaseAuth: FirebaseAuth
-) : GoogleApiClient{
+    private val firebaseAuth: FirebaseAuth,
+) : GoogleApiClient {
     override fun getUserInfo(authorizationCode: String): UserInfo {
         val decodedToken = verifyIdToken(authorizationCode)
         return UserInfo(decodedToken.email) // 로그인 한 사용자의 이메일

--- a/application/src/main/kotlin/com/pokit/user/port/out/UserPort.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/UserPort.kt
@@ -6,4 +6,6 @@ interface UserPort {
     fun persist(user: User): User
 
     fun loadByEmail(email: String): User?
+
+    fun loadById(id: Long): User?
 }

--- a/application/src/test/kotlin/com/pokit/auth/port/service/AuthServiceTest.kt
+++ b/application/src/test/kotlin/com/pokit/auth/port/service/AuthServiceTest.kt
@@ -5,7 +5,6 @@ import com.pokit.auth.port.`in`.TokenProvider
 import com.pokit.auth.port.out.AppleApiClient
 import com.pokit.auth.port.out.GoogleApiClient
 import com.pokit.common.exception.ClientValidationException
-import com.pokit.out.persistence.user.persist.UserRepository
 import com.pokit.user.UserFixture
 import com.pokit.user.port.out.UserPort
 import io.kotest.assertions.throwables.shouldThrow

--- a/domain/src/main/kotlin/com/pokit/user/exception/UserErrorCode.kt
+++ b/domain/src/main/kotlin/com/pokit/user/exception/UserErrorCode.kt
@@ -7,4 +7,5 @@ enum class UserErrorCode(
     override val code: String,
 ) : ErrorCode {
     INVALID_EMAIL("올바르지 않은 이메일 형식의 유저입니다.", "U_001"),
+    NOT_FOUND_USER("회원을 찾을 수 없습니다.", "U_002"),
 }

--- a/domain/src/main/kotlin/com/pokit/user/model/InterestType.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/InterestType.kt
@@ -3,5 +3,5 @@ package com.pokit.user.model
 enum class InterestType(
     val kor: String,
 ) {
-    SPORTS("스포츠/레저")
+    SPORTS("스포츠/레저"),
 }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #14 

### 📍 리뷰 포인트

- JWT 커스텀 필터에 추가된 로직 [#1828](https://github.com/YAPP-Github/24th-App-Team-4-BE/commit/18284016b03f38df08ba49409d2eb035ee3741eb)
- UserDetails 구현 클래스

### 📝 참고사항(Optional)

- 컨트롤러에서 @AuthenticationPrincipal로 유저 객체 받는걸로 생각하고 구현했습니다~!
```kotlin
@PostMapping
fun userTask(
    @AuthenticationPrincipal principalUser: PrincipalUser
) {
    val user = principalUser.toDomain()
    usecase.someMethod(user)
}
```
user domain에서 UserDetails를 구현할 수 없어서 in-web 모듈에 정의했고 application 계층에 유저 넘겨줄 때 어쩔 수 없이 도메인으로 변환 로직이 들어갔는데 다른 좋은 의견 있으면 주세요ㅠㅠ
- 마지막 커밋은 코드 포맷팅이라 안 보셔도됩니다.
