### PR TITLE
[feat #19] 회원가입 API

### DIFF
--- a/adapters/in-web/build.gradle.kts
+++ b/adapters/in-web/build.gradle.kts
@@ -16,6 +16,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.data:spring-data-commons")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
 
     // 테스팅
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.1")

--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/AuthController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/AuthController.kt
@@ -1,7 +1,10 @@
 package com.pokit.auth
 
+import com.pokit.auth.config.ErrorOperation
 import com.pokit.auth.port.`in`.AuthUseCase
 import com.pokit.token.dto.request.SignInRequest
+import com.pokit.user.exception.UserErrorCode
+import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -14,6 +17,8 @@ class AuthController(
     private val authUseCase: AuthUseCase,
 ) {
     @PostMapping("/signin")
+    @Operation(summary = "로그인 API")
+    @ErrorOperation(UserErrorCode::class)
     fun signIn(
         @RequestBody request: SignInRequest,
     ) = ResponseEntity.ok(authUseCase.signIn(request))

--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/config/ErrorOperation.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/config/ErrorOperation.kt
@@ -1,0 +1,8 @@
+package com.pokit.auth.config
+
+import com.pokit.common.exception.ErrorCode
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class ErrorOperation(val value: KClass<out ErrorCode>)

--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/config/SecurityConfig.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/config/SecurityConfig.kt
@@ -17,7 +17,16 @@ class SecurityConfig(
     private val entryPoint: AuthenticationEntryPoint,
 ) {
     companion object {
-        private val WHITE_LIST = arrayOf("/api/v1/auth/**")
+        private val WHITE_LIST = arrayOf(
+            "/api/v1/auth/**",
+            "/swagger-ui/index.html#/",
+            "/swagger",
+            "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/api-docs",
+            "/api-docs/**",
+            "/v3/api-docs/**"
+        )
     }
 
     @Bean

--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/config/SwaggerConfig.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/config/SwaggerConfig.kt
@@ -1,0 +1,32 @@
+package com.pokit.auth.config
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.media.Schema
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .components(
+                Components()
+                    .addSchemas(
+                        "ErrorResponse", Schema<Any>()
+                            .addProperty("message", Schema<Any>().type("string"))
+                            .addProperty("code", Schema<Any>().type("string"))
+                    )
+            )
+            .info(configurationInfo())
+    }
+
+    private fun configurationInfo(): Info {
+        return Info()
+            .title("POKIT API")
+            .description("포킷 api 명세서")
+            .version("1.0")
+    }
+}

--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/filter/CustomAuthenticationFilter.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/filter/CustomAuthenticationFilter.kt
@@ -20,7 +20,15 @@ class CustomAuthenticationFilter(
     private val tokenProvider: TokenProvider,
 ) : OncePerRequestFilter() {
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
-        val excludePath = arrayOf("/api/v1/auth/signin")
+        val excludePath = arrayOf(
+            "/api/v1/auth/signin",
+            "/swagger-ui/index.html#/",
+            "/swagger", "/swagger-ui.html",
+            "/swagger-ui/**",
+            "/api-docs",
+            "/api-docs/**",
+            "/v3/api-docs/**"
+        )
         val path = request.requestURI
         val shouldNotFilter =
             excludePath

--- a/adapters/in-web/src/main/kotlin/com/pokit/common/exception/ApiErrorOperationCustomizer.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/common/exception/ApiErrorOperationCustomizer.kt
@@ -1,0 +1,50 @@
+package com.pokit.common.exception
+
+import com.pokit.auth.config.ErrorOperation
+import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.examples.Example
+import io.swagger.v3.oas.models.media.Content
+import io.swagger.v3.oas.models.media.MediaType
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.responses.ApiResponse
+import io.swagger.v3.oas.models.responses.ApiResponses
+import org.springdoc.core.customizers.OperationCustomizer
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+
+@Component
+class ApiErrorOperationCustomizer : OperationCustomizer {
+    override fun customize(operation: Operation, handlerMethod: HandlerMethod): Operation {
+        val annotation = handlerMethod.method.getAnnotation(ErrorOperation::class.java)
+        if (annotation != null) {
+            val errorCodeClass = annotation.value.java
+            val errorCodes = errorCodeClass.enumConstants
+            val apiResponses = ApiResponses()
+
+            for (errorCode in errorCodes) {
+                val exampleContent = ErrorResponse(errorCode.message, errorCode.code)
+
+                val example = Example().apply {
+                    value = exampleContent
+                }
+
+                val mediaType = MediaType().apply {
+                    addExamples("example", example)
+                    schema = Schema<ErrorResponse>()
+                }
+
+                val content = Content().apply {
+                    addMediaType(org.springframework.http.MediaType.APPLICATION_JSON_VALUE, mediaType)
+                }
+
+                val response = ApiResponse()
+                    .description("${errorCode.code}: ${errorCode.message}")
+                    .content(content)
+                apiResponses.addApiResponse(errorCode.code, response)
+            }
+
+            operation.responses(apiResponses)
+        }
+        return operation
+    }
+}

--- a/adapters/in-web/src/main/kotlin/com/pokit/common/exception/ApiErrorOperationCustomizer.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/common/exception/ApiErrorOperationCustomizer.kt
@@ -19,7 +19,7 @@ class ApiErrorOperationCustomizer : OperationCustomizer {
         if (annotation != null) {
             val errorCodeClass = annotation.value.java
             val errorCodes = errorCodeClass.enumConstants
-            val apiResponses = ApiResponses()
+            val apiResponses = operation.responses ?: ApiResponses()
 
             for (errorCode in errorCodes) {
                 val exampleContent = ErrorResponse(errorCode.message, errorCode.code)

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
@@ -1,0 +1,34 @@
+package com.pokit.user
+
+import com.pokit.auth.config.ErrorOperation
+import com.pokit.user.dto.ApiSignUpRequest
+import com.pokit.user.dto.response.SignUpResponse
+import com.pokit.user.exception.UserErrorCode
+import com.pokit.user.model.User
+import com.pokit.user.port.`in`.UserUseCase
+import io.swagger.v3.oas.annotations.Operation
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/user")
+class UserController(
+    private val userUseCase: UserUseCase
+) {
+    @PostMapping("/signup")
+    @Operation(summary = "회원 등록 API")
+    @ErrorOperation(UserErrorCode::class)
+    fun signUp(
+        @AuthenticationPrincipal user: User,
+        @Valid @RequestBody request: ApiSignUpRequest
+    ): ResponseEntity<SignUpResponse> {
+        val signUpRequest = request.toSignUpRequest()
+        val response = userUseCase.signUp(user, signUpRequest)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
@@ -1,6 +1,8 @@
 package com.pokit.user
 
 import com.pokit.auth.config.ErrorOperation
+import com.pokit.auth.model.PrincipalUser
+import com.pokit.auth.model.toDomain
 import com.pokit.user.dto.ApiSignUpRequest
 import com.pokit.user.dto.response.SignUpResponse
 import com.pokit.user.exception.UserErrorCode
@@ -24,9 +26,10 @@ class UserController(
     @Operation(summary = "회원 등록 API")
     @ErrorOperation(UserErrorCode::class)
     fun signUp(
-        @AuthenticationPrincipal user: User,
+        @AuthenticationPrincipal principalUser: PrincipalUser,
         @Valid @RequestBody request: ApiSignUpRequest
     ): ResponseEntity<SignUpResponse> {
+        val user = principalUser.toDomain()
         val signUpRequest = request.toSignUpRequest()
         val response = userUseCase.signUp(user, signUpRequest)
         return ResponseEntity.ok(response)

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/dto/ApiSignUpRequest.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/dto/ApiSignUpRequest.kt
@@ -7,8 +7,9 @@ import jakarta.validation.constraints.Size
 
 data class ApiSignUpRequest(
     @NotBlank(message = "닉네임은 필수값입니다.")
+    @Size(max = 10, message = "닉네임은 10자 이하만 가능합니다.")
     val nickName: String,
-    @Size(min = 1, message = "최소 하나 이상이어야 합니다.")
+    @Size(min = 1, max = 3, message = "최소 하나 이상, 세개 이하만 가능합니다.")
     val interests: List<String>
 ) {
     fun toSignUpRequest(): SignUpRequest {

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/dto/ApiSignUpRequest.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/dto/ApiSignUpRequest.kt
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class ApiSignUpRequest(
-    @NotBlank(message = "이메일은 필수값입니다.")
+    @NotBlank(message = "닉네임은 필수값입니다.")
     val nickName: String,
     @Size(min = 1, message = "최소 하나 이상이어야 합니다.")
     val interests: List<String>

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/dto/ApiSignUpRequest.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/dto/ApiSignUpRequest.kt
@@ -1,0 +1,24 @@
+package com.pokit.user.dto
+
+import com.pokit.user.dto.request.SignUpRequest
+import com.pokit.user.model.InterestType
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class ApiSignUpRequest(
+    @NotBlank(message = "이메일은 필수값입니다.")
+    val nickName: String,
+    @Size(min = 1, message = "최소 하나 이상이어야 합니다.")
+    val interests: List<String>
+) {
+    fun toSignUpRequest(): SignUpRequest {
+        val interestTypes = interests.map {
+            InterestType.of(it)
+        }
+
+        return SignUpRequest(
+            nickName = nickName,
+            interests = interestTypes
+        )
+    }
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
@@ -2,9 +2,11 @@ package com.pokit.out.persistence.user.impl
 
 import com.pokit.out.persistence.user.persist.UserEntity
 import com.pokit.out.persistence.user.persist.UserRepository
+import com.pokit.out.persistence.user.persist.registerInfo
 import com.pokit.out.persistence.user.persist.toDomain
 import com.pokit.user.model.User
 import com.pokit.user.port.out.UserPort
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -20,5 +22,11 @@ class UserAdapter(
     override fun loadByEmail(email: String): User? {
         val userJpaEntity = userRepository.findByEmail(email)
         return userJpaEntity?.toDomain()
+    }
+
+    override fun register(user: User): User? {
+        val userEntity = userRepository.findByIdOrNull(user.id)
+        userEntity?.registerInfo(user)
+        return userEntity?.toDomain()
     }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
@@ -17,6 +17,9 @@ class UserEntity(
 
     @Column(name = "role")
     val role: Role,
+
+    @Column(name = "nickname")
+    var nickName: String = email,
 ) {
     companion object {
         fun of(user: User) =
@@ -30,3 +33,7 @@ class UserEntity(
 fun UserEntity.toDomain() = User(id = this.id, email = this.email, role = this.role)
 
 fun UserEntity.toPrincipalUser() = null // Security Context에 담을 user
+
+fun UserEntity.registerInfo(user: User) {
+    this.nickName = user.nickName
+}

--- a/adapters/out-persistence/src/testFixtures/kotlin/com/pokit/user/UserFixture.kt
+++ b/adapters/out-persistence/src/testFixtures/kotlin/com/pokit/user/UserFixture.kt
@@ -1,6 +1,8 @@
 package com.pokit.user
 
 import com.pokit.user.dto.UserInfo
+import com.pokit.user.dto.request.SignUpRequest
+import com.pokit.user.model.InterestType
 import com.pokit.user.model.Role
 import com.pokit.user.model.User
 
@@ -9,5 +11,9 @@ class UserFixture {
         fun getUser() = User(1L, "ij@naver.com", Role.USER)
 
         fun getUserInfo() = UserInfo("ig@naver.com")
+
+        fun getInvalidUser() = User(2L, "dls@naver.com", Role.USER)
+
+        fun getSignUpRequest() = SignUpRequest("인주니", listOf(InterestType.SPORTS))
     }
 }

--- a/application/src/main/kotlin/com/pokit/user/port/in/UserUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/in/UserUseCase.kt
@@ -1,0 +1,9 @@
+package com.pokit.user.port.`in`
+
+import com.pokit.user.dto.request.SignUpRequest
+import com.pokit.user.dto.response.SignUpResponse
+import com.pokit.user.model.User
+
+interface UserUseCase {
+    fun signUp(user: User, request: SignUpRequest): SignUpResponse
+}

--- a/application/src/main/kotlin/com/pokit/user/port/out/UserRepository.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/UserRepository.kt
@@ -6,4 +6,6 @@ interface UserPort {
     fun persist(user: User): User
 
     fun loadByEmail(email: String): User?
+
+    fun register(user: User): User?
 }

--- a/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
@@ -1,0 +1,29 @@
+package com.pokit.user.port.service
+
+import com.pokit.common.exception.NotFoundCustomException
+import com.pokit.user.dto.request.SignUpRequest
+import com.pokit.user.dto.response.SignUpResponse
+import com.pokit.user.exception.UserErrorCode
+import com.pokit.user.model.User
+import com.pokit.user.port.`in`.UserUseCase
+import com.pokit.user.port.out.UserPort
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class UserService(
+    private val userPort: UserPort
+) : UserUseCase {
+    @Transactional
+    override fun signUp(user: User, request: SignUpRequest): SignUpResponse {
+        user.modifyUser(
+            request.nickName,
+        )
+
+        val savedUser = userPort.register(user)
+            ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_USER)
+
+        return SignUpResponse(savedUser.id)
+    }
+}

--- a/application/src/test/kotlin/com/pokit/user/port/service/UserServiceTest.kt
+++ b/application/src/test/kotlin/com/pokit/user/port/service/UserServiceTest.kt
@@ -1,0 +1,44 @@
+package com.pokit.user.port.service
+
+import com.pokit.common.exception.NotFoundCustomException
+import com.pokit.user.UserFixture
+import com.pokit.user.model.User
+import com.pokit.user.port.out.UserPort
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+
+class UserServiceTest : BehaviorSpec({
+    val userPort = mockk<UserPort>()
+    val userService = UserService(userPort)
+    Given("회원을 등록할 때") {
+        val user = UserFixture.getUser()
+        val invalidUser = UserFixture.getInvalidUser()
+        val request = UserFixture.getSignUpRequest()
+        val modifieUser = User(user.id, user.email, user.role, request.nickName)
+
+        every { userPort.register(user) } returns modifieUser
+        every { userPort.register(invalidUser) } returns null
+
+        When("수정하려는 정보를 받으면") {
+            val response = userService.signUp(user, request)
+            Then("회원 정보가 수정되고 수정된 회원의 id가 반환된다.") {
+                response.userId shouldBe modifieUser.id
+                user.nickName shouldBe modifieUser.nickName
+            }
+        }
+
+        When("수정하려는 회원을 찾을 수 없으면") {
+            Then("예외가 발생한다.") {
+                shouldThrow<NotFoundCustomException> {
+                    userService.signUp(invalidUser, request)
+                }
+            }
+        }
+
+
+    }
+
+})

--- a/domain/src/main/kotlin/com/pokit/user/dto/request/SignUpRequest.kt
+++ b/domain/src/main/kotlin/com/pokit/user/dto/request/SignUpRequest.kt
@@ -1,0 +1,9 @@
+package com.pokit.user.dto.request
+
+import com.pokit.user.model.InterestType
+
+data class SignUpRequest(
+    val nickName: String,
+    val interests: List<InterestType>
+) {
+}

--- a/domain/src/main/kotlin/com/pokit/user/dto/response/SignUpResponse.kt
+++ b/domain/src/main/kotlin/com/pokit/user/dto/response/SignUpResponse.kt
@@ -1,0 +1,6 @@
+package com.pokit.user.dto.response
+
+class SignUpResponse(
+    val userId: Long
+) {
+}

--- a/domain/src/main/kotlin/com/pokit/user/exception/UserErrorCode.kt
+++ b/domain/src/main/kotlin/com/pokit/user/exception/UserErrorCode.kt
@@ -7,4 +7,6 @@ enum class UserErrorCode(
     override val code: String,
 ) : ErrorCode {
     INVALID_EMAIL("올바르지 않은 이메일 형식의 유저입니다.", "U_001"),
+    INVALID_INTEREST_TYPE("관심사가 잘못되었습니다.", "U_002"),
+    NOT_FOUND_USER("존재하지 않는 회원입니다.", "U_003")
 }

--- a/domain/src/main/kotlin/com/pokit/user/model/InterestType.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/InterestType.kt
@@ -1,7 +1,18 @@
 package com.pokit.user.model
 
+import com.pokit.common.exception.ClientValidationException
+import com.pokit.user.exception.UserErrorCode
+
 enum class InterestType(
     val kor: String,
 ) {
-    SPORTS("스포츠/레저")
+    SPORTS("스포츠/레저");
+
+    companion object {
+        fun of(input: String): InterestType {
+            return InterestType.entries
+                .firstOrNull { it.kor == input }
+                ?: throw ClientValidationException(UserErrorCode.INVALID_INTEREST_TYPE)
+        }
+    }
 }

--- a/domain/src/main/kotlin/com/pokit/user/model/InterestType.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/InterestType.kt
@@ -1,5 +1,8 @@
 package com.pokit.user.model
 
+import com.pokit.common.exception.ClientValidationException
+import com.pokit.user.exception.UserErrorCode
+
 enum class InterestType(
     val kor: String,
 ) {

--- a/domain/src/main/kotlin/com/pokit/user/model/User.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/User.kt
@@ -8,7 +8,12 @@ data class User(
     val id: Long = 0L,
     val email: String,
     val role: Role,
+    var nickName: String = email
 ) {
+    fun modifyUser(nickName: String) {
+        this.nickName = nickName
+    }
+
     init {
         val pattern =
             Pattern.compile(


### PR DESCRIPTION
### ⛏ 이슈 번호

close #19 

### 📍 리뷰 포인트

- 회원가입 로직
- 스웨거 설정
- 응답을 지금처럼 회원 id만 할 지, 수정된 회원 정보 다 반환할 지

### 📝 참고사항(Optional)

- 요청 dto는 in-web과 application을 분리했습니다! in-web dto는 validation + string -> enum으로 변환 로직
- pr쓰다 생각 났는데 관심사 모델을 만들어서 저장해야되는데 그게 없네요 다른 작업에서 추가하겠습니다!