### PR TITLE
[feat #45] 컨텐츠 검색 API

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/content/dto/request/ContentSearchParams.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/dto/request/ContentSearchParams.kt
@@ -1,0 +1,24 @@
+package com.pokit.content.dto.request
+
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDate
+
+data class ContentSearchParams(
+    val categoryId: Long?,
+    val isRead: Boolean?,
+    val favorites: Boolean?,
+    @DateTimeFormat(pattern = "yyyy.MM.dd")
+    val startDate: LocalDate?,
+    @DateTimeFormat(pattern = "yyyy.MM.dd")
+    val endDate: LocalDate?,
+    val categoryIds: List<Long>?
+)
+
+internal fun ContentSearchParams.toDto() = ContentSearchCondition(
+    categoryId = this.categoryId,
+    isRead = this.isRead,
+    favorites = this.favorites,
+    startDate = this.startDate,
+    endDate = this.endDate,
+    categoryIds = this.categoryIds
+)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
@@ -12,7 +12,6 @@ import com.pokit.out.persistence.content.persist.ContentRepository
 import com.pokit.out.persistence.content.persist.QContentEntity.contentEntity
 import com.pokit.out.persistence.content.persist.toDomain
 import com.pokit.out.persistence.log.persist.QUserLogEntity.userLogEntity
-import com.pokit.out.persistence.user.persist.QUserEntity.userEntity
 import com.querydsl.core.Tuple
 import com.querydsl.core.types.Predicate
 import com.querydsl.core.types.dsl.DateTimePath
@@ -62,12 +61,11 @@ class ContentAdapter(
             .from(contentEntity)
             .leftJoin(userLogEntity).on(userLogEntity.contentId.eq(contentEntity.id))
             .join(categoryEntity).on(categoryEntity.id.eq(contentEntity.categoryId))
-            .join(userEntity).on(userEntity.id.eq(categoryEntity.userId))
 
         FavoriteOrNot(condition.favorites, query) // 북마크 조인 여부
 
         query.where(
-            userEntity.id.eq(userId),
+            categoryEntity.userId.eq(userId),
             condition.categoryId?.let { categoryEntity.id.eq(it) },
             isUnread(condition.isRead),
             contentEntity.deleted.isFalse,

--- a/adapters/out-persistence/src/test/kotlin/com/pokit/out/persistence/content/impl/ContentAdapterTest.kt
+++ b/adapters/out-persistence/src/test/kotlin/com/pokit/out/persistence/content/impl/ContentAdapterTest.kt
@@ -150,17 +150,23 @@ class ContentAdapterTest(
                     readContent!!.contentId shouldBe userLog.contentId
                 }
             }
+            val anotherImage = CategoryImage(2, "www.s3.com")
+            val savedAnotherImage = categoryImageRepository.save(CategoryImageEntity.of(anotherImage))
 
             val anotherCategory = Category(
                 userId = savedUser.id,
                 categoryName = "다른 카테고리",
-                categoryImage = savedImage.toDomain()
+                categoryImage = savedAnotherImage.toDomain()
             )
-            categoryRepository.save(CategoryEntity.of(anotherCategory))
+            val savedAnotherCategory = categoryRepository.save(CategoryEntity.of(anotherCategory))
+
+            val content3 = ContentFixture.getContent(savedAnotherCategory.id)
+            contentRepository.save(ContentEntity.of(content3))
+
 
             When("카테고리명 하나로 필터링할 때") {
                 val result = contentAdapter.loadAllByUserIdAndContentId(
-                    savedUser.id, condition.copy(categoryIds = mutableListOf(category.categoryId)), pageRequest
+                    savedUser.id, condition.copy(categoryId = null, categoryIds = mutableListOf(savedCategory.id)), pageRequest
                 )
                 Then("해당 카테고리의 컨텐츠들이 조회된다.") {
                     result.content.size shouldBe 2
@@ -170,7 +176,7 @@ class ContentAdapterTest(
             When("카테고리명 두개로 필터링할 때") {
                 val result = contentAdapter.loadAllByUserIdAndContentId(
                     savedUser.id,
-                    condition.copy(categoryIds = mutableListOf(category.categoryId, anotherCategory.categoryId)),
+                    condition.copy(categoryId = null, categoryIds = mutableListOf(savedCategory.id, savedAnotherCategory.id)),
                     pageRequest
                 )
                 Then("둘 중 하나라도 만족하면 조회된다.") {

--- a/adapters/out-persistence/src/testFixtures/kotlin/com/pokit/content/ContentFixture.kt
+++ b/adapters/out-persistence/src/testFixtures/kotlin/com/pokit/content/ContentFixture.kt
@@ -1,6 +1,7 @@
 package com.pokit.content
 
 import com.pokit.content.dto.ContentCommand
+import com.pokit.content.dto.request.ContentSearchCondition
 import com.pokit.content.model.Content
 import com.pokit.content.model.ContentType
 
@@ -47,6 +48,15 @@ class ContentFixture {
             categoryId = categoryId,
             memo = "네이버우어",
             alertYn = "YES"
+        )
+
+        fun getCondition(categoryId: Long) = ContentSearchCondition(
+            categoryId = categoryId,
+            isRead = null,
+            favorites = null,
+            startDate = null,
+            endDate = null,
+            categoryIds = null
         )
     }
 }

--- a/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
@@ -1,6 +1,8 @@
 package com.pokit.content.port.`in`
 
 import com.pokit.content.dto.ContentCommand
+import com.pokit.content.dto.ContentsResponse
+import com.pokit.content.dto.request.ContentSearchCondition
 import com.pokit.content.dto.response.BookMarkContentResponse
 import com.pokit.content.dto.response.GetContentResponse
 import com.pokit.content.model.Content
@@ -20,11 +22,9 @@ interface ContentUseCase {
 
     fun getContents(
         userId: Long,
-        categoryId: Long,
+        condition: ContentSearchCondition,
         pageable: Pageable,
-        isRead: Boolean?,
-        favorites: Boolean?
-    ): Slice<Content>
+    ): Slice<ContentsResponse>
 
     fun getContent(userId: Long, contentId: Long): GetContentResponse
 }

--- a/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
@@ -1,5 +1,7 @@
 package com.pokit.content.port.out
 
+import com.pokit.content.dto.ContentsResponse
+import com.pokit.content.dto.request.ContentSearchCondition
 import com.pokit.content.model.Content
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
@@ -15,11 +17,9 @@ interface ContentPort {
 
     fun loadAllByUserIdAndContentId(
         userId: Long,
-        categoryId: Long,
+        condition: ContentSearchCondition,
         pageable: Pageable,
-        read: Boolean?,
-        favorites: Boolean?
-    ): Slice<Content>
+    ): Slice<ContentsResponse>
 
     fun deleteByUserId(userId: Long)
 }

--- a/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
@@ -7,6 +7,8 @@ import com.pokit.category.model.Category
 import com.pokit.category.port.out.CategoryPort
 import com.pokit.common.exception.NotFoundCustomException
 import com.pokit.content.dto.ContentCommand
+import com.pokit.content.dto.ContentsResponse
+import com.pokit.content.dto.request.ContentSearchCondition
 import com.pokit.content.dto.response.BookMarkContentResponse
 import com.pokit.content.dto.response.GetContentResponse
 import com.pokit.content.dto.response.toGetContentResponse
@@ -72,17 +74,13 @@ class ContentService(
 
     override fun getContents(
         userId: Long,
-        categoryId: Long,
+        condition: ContentSearchCondition,
         pageable: Pageable,
-        isRead: Boolean?,
-        favorites: Boolean?
-    ): Slice<Content> {
+    ): Slice<ContentsResponse> {
         val contents = contentPort.loadAllByUserIdAndContentId(
             userId,
-            categoryId,
+            condition,
             pageable,
-            isRead,
-            favorites
         )
 
         return contents

--- a/domain/src/main/kotlin/com/pokit/content/dto/ContentsResponse.kt
+++ b/domain/src/main/kotlin/com/pokit/content/dto/ContentsResponse.kt
@@ -1,0 +1,36 @@
+package com.pokit.content.dto
+
+import com.pokit.content.model.Content
+import java.time.format.DateTimeFormatter
+
+data class ContentsResponse(
+    val contentId: Long,
+    val categoryId: Long,
+    val categoryName: String,
+    val data: String,
+    val domain: String,
+    val title: String,
+    val memo: String,
+    val alertYn: String,
+    val createdAt: String,
+    val isRead: Boolean
+) {
+    companion object {
+        fun of(content: Content, categoryName: String, isRead: Long): ContentsResponse {
+            val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
+
+            return ContentsResponse(
+                contentId = content.id,
+                categoryId = content.categoryId,
+                categoryName = categoryName,
+                data = content.data,
+                domain = content.domain,
+                title = content.title,
+                memo = content.memo,
+                alertYn = content.alertYn,
+                createdAt = content.createdAt.format(formatter),
+                isRead = isRead > 0
+            )
+        }
+    }
+}

--- a/domain/src/main/kotlin/com/pokit/content/dto/request/ContentSearchCondition.kt
+++ b/domain/src/main/kotlin/com/pokit/content/dto/request/ContentSearchCondition.kt
@@ -1,0 +1,12 @@
+package com.pokit.content.dto.request
+
+import java.time.LocalDate
+
+data class ContentSearchCondition(
+    val categoryId: Long?,
+    val isRead: Boolean?,
+    val favorites: Boolean?,
+    val startDate: LocalDate?,
+    val endDate: LocalDate?,
+    val categoryIds: List<Long>?
+)


### PR DESCRIPTION
### ⛏ 이슈 번호

close #45 

### 📍 리뷰 포인트

- 쿼리는 기존걸 활용하고 검색 응용 서비스도 따로 만들지 않았습미다. API만 따로 분리했는데 분리한 이유는 쿼리 파라미터 관련해서 프론트측에서 헷갈려 하실까봐 분리했습니당
    - categoryId 필수 여부로 두 API가 나뉨(카테고리 내 컨텐츠 목록, 검색)
- 쿼리 이상 및 테스트
- 어댑터에서 dto를 말아서 반환하는데 괜찮은 지..(아님 더 조은 의견) 
- dto 패키지 이상

### 📝 참고사항(Optional)
쿼리는 요렇게 나가고 컨텐츠 별로 유저로그 개수를 가져옵니다. 개수가 양수면 읽음 0이면 안읽음
```sql
select
        ce1_0.id,
        ...컨텐츠 필드들
        ce2_0.name,
        count(ule1_0.id) 
    from
        content ce1_0 
    left join
        user_log ule1_0 
            on ule1_0.content_id=ce1_0.id 
    join
        category ce2_0 
            on ce2_0.id=ce1_0.category_id 
    join
        user ue1_0 
            on ue1_0.id=ce2_0.user_id 
    where
        ue1_0.id=? 
        and ce2_0.id=? 
        and ce1_0.is_deleted=? 
    group by
        ce1_0.id 
    order by
        ce1_0.created_at desc 
    limit
        ?
```