### PR TITLE
[feat #78] 미분류 컨텐츠 조회 api

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/content/ContentController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/ContentController.kt
@@ -4,6 +4,7 @@ import com.pokit.auth.config.ErrorOperation
 import com.pokit.auth.model.PrincipalUser
 import com.pokit.auth.model.toDomain
 import com.pokit.category.exception.CategoryErrorCode
+import com.pokit.category.model.CategoryStatus
 import com.pokit.common.dto.SliceResponseDto
 import com.pokit.common.wrapper.ResponseWrapper.wrapOk
 import com.pokit.common.wrapper.ResponseWrapper.wrapSlice
@@ -108,6 +109,27 @@ class ContentController(
         return contentUseCase.getContents(
             user.id,
             condition.copy(categoryId = categoryId).toDto(),
+            pageable
+        )
+            .map { it.toResponse() }
+            .wrapSlice()
+            .wrapOk()
+    }
+
+    @GetMapping("/uncategorized")
+    @Operation(summary = "미분류 카테고리 컨텐츠 조회")
+    fun getUncategorizedContents(
+        @AuthenticationPrincipal user: PrincipalUser,
+        @PageableDefault(
+            page = 0,
+            size = 10,
+            sort = ["createdAt"],
+            direction = Sort.Direction.DESC
+        ) pageable: Pageable,
+    ): ResponseEntity<SliceResponseDto<ContentsResponse>> {
+        return contentUseCase.getContentsByCategoryName(
+            user.id,
+            CategoryStatus.UNCATEGORIZED.name,
             pageable
         )
             .map { it.toResponse() }

--- a/adapters/in-web/src/main/kotlin/com/pokit/content/dto/response/ContentsResponse.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/dto/response/ContentsResponse.kt
@@ -1,11 +1,11 @@
 package com.pokit.content.dto.response
 
+import com.pokit.category.model.RemindCategory
 import java.time.format.DateTimeFormatter
 
 data class ContentsResponse(
     val contentId: Long,
-    val categoryId: Long,
-    val categoryName: String,
+    val category: RemindCategory,
     val data: String,
     val domain: String,
     val title: String,
@@ -21,8 +21,7 @@ fun ContentsResult.toResponse(): ContentsResponse {
 
     return ContentsResponse(
         contentId = this.contentId,
-        categoryId = this.categoryId,
-        categoryName = this.categoryName,
+        category = this.category,
         data = this.data,
         domain = this.domain,
         title = this.title,

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
@@ -76,6 +76,7 @@ class ContentAdapter(
             dateBetween(condition.startDate, condition.endDate),
             categoryIn(condition.categoryIds)
         )
+            .offset(pageable.offset)
             .groupBy(contentEntity)
             .orderBy(getSort(contentEntity.createdAt, order!!))
             .limit(pageable.pageSize + 1L)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentEntity.kt
@@ -32,6 +32,9 @@ class ContentEntity(
     @Column(name = "alert_yn")
     val alertYn: String,
 
+    @Column(name = "domain")
+    val domain: String,
+
     @Column(name = "is_deleted")
     var deleted: Boolean = false
 ) : BaseEntity() {
@@ -47,7 +50,8 @@ class ContentEntity(
             data = content.data,
             title = content.title,
             memo = content.memo,
-            alertYn = content.alertYn
+            alertYn = content.alertYn,
+            domain = content.domain
         )
     }
 }
@@ -60,5 +64,6 @@ fun ContentEntity.toDomain() = Content(
     title = this.title,
     memo = this.memo,
     alertYn = this.alertYn,
+    domain = this.domain,
     createdAt = this.createdAt
 )

--- a/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
@@ -28,6 +28,8 @@ interface ContentUseCase {
         pageable: Pageable,
     ): Slice<ContentsResult>
 
+    fun getContentsByCategoryName(userId: Long, categoryName: String, pageable: Pageable): Slice<ContentsResult>
+
     fun getContent(userId: Long, contentId: Long): GetContentResponse
 
     fun getBookmarkContents(userId: Long, pageable: Pageable): Slice<RemindContentResult>

--- a/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
@@ -23,6 +23,12 @@ interface ContentPort {
         pageable: Pageable,
     ): Slice<ContentsResult>
 
+    fun loadByUserIdAndCategoryName(
+        userId: Long,
+        categoryName: String,
+        pageable: Pageable,
+    ): Slice<ContentsResult>
+
     fun deleteByUserId(userId: Long)
 
     fun loadByContentIds(contentIds: List<Long>): List<Content>

--- a/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
@@ -95,6 +95,10 @@ class ContentService(
         return contents
     }
 
+    override fun getContentsByCategoryName(userId: Long, categoryName: String, pageable: Pageable): Slice<ContentsResult> =
+        contentPort.loadByUserIdAndCategoryName(userId, categoryName, pageable)
+
+
     @Transactional
     override fun getContent(userId: Long, contentId: Long): GetContentResponse {
         val userLog = UserLog(

--- a/domain/src/main/kotlin/com/pokit/category/model/CategoryStatus.kt
+++ b/domain/src/main/kotlin/com/pokit/category/model/CategoryStatus.kt
@@ -1,5 +1,16 @@
 package com.pokit.category.model
 
-enum class CategoryStatus(val displayName: String) {
+enum class CategoryStatus(
+    val displayName: String
+) {
     UNCATEGORIZED("미분류")
+    ;
+
+    companion object {
+        fun resolveDisplayName(status: String): String =
+            entries.find { it.name == status }
+                ?.displayName
+                ?: status
+
+    }
 }

--- a/domain/src/main/kotlin/com/pokit/content/dto/response/ContentsResult.kt
+++ b/domain/src/main/kotlin/com/pokit/content/dto/response/ContentsResult.kt
@@ -1,12 +1,12 @@
 package com.pokit.content.dto.response
 
+import com.pokit.category.model.RemindCategory
 import com.pokit.content.model.Content
 import java.time.LocalDateTime
 
 data class ContentsResult(
     val contentId: Long,
-    val categoryId: Long,
-    val categoryName: String,
+    val category: RemindCategory,
     val data: String,
     val domain: String,
     val title: String,
@@ -20,8 +20,7 @@ data class ContentsResult(
         fun of(content: Content, categoryName: String, isRead: Long): ContentsResult {
             return ContentsResult(
                 contentId = content.id,
-                categoryId = content.categoryId,
-                categoryName = categoryName,
+                category = RemindCategory(content.categoryId, categoryName),
                 data = content.data,
                 domain = content.domain,
                 title = content.title,

--- a/domain/src/main/kotlin/com/pokit/content/dto/response/RemindContentResult.kt
+++ b/domain/src/main/kotlin/com/pokit/content/dto/response/RemindContentResult.kt
@@ -30,7 +30,7 @@ fun Content.toRemindContentResult(isRead: Boolean, category: RemindCategory): Re
 fun ContentsResult.toRemindContentResult(): RemindContentResult {
     return RemindContentResult(
         contentId = this.contentId,
-        category = RemindCategory(this.categoryId, this.categoryName),
+        category = this.category,
         data = this.data,
         title = this.title,
         createdAt = this.createdAt,


### PR DESCRIPTION
### ⛏ 이슈 번호
close #78 

### 📍 리뷰 포인트
* `getHasNext` 공통으로 빼면서 영향간 부분 없는지

📝 참고사항(Optional)
* 검색 부분 페이징 처리 제대로 안되고 있어서 offset 추가했슴여
* remindCategory 로 사용했던 부분 체리픽으로 들고온건데 네이밍은 추후 일괄 변경하는걸로 하져,,
* ContentEntity 의 domain 필드가 역머지하면서 누락되었어서 이번 커밋에 추가되었숨니다