### PR TITLE
[feat #116] 알림 전송 배치 작업

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -44,6 +44,8 @@ jobs:
           echo "${{ secrets.OUT_WEB_YML }}" > ./adapters/out-web/src/main/resources/application-out-web.yml
           mkdir -p ./application/src/main/resources
           echo "${{ secrets.APPLICATION_CORE }}" > ./application/src/main/resources/application-core.yml
+          mkdir -p ./adapters/in-batch/src/main/resources
+          echo "${{ secrets.APPLICATION_IN_BATCH }}" > ./application/src/main/resources/application-in-batch.yml
 
       - name: Build with Gradle
         run: ./gradlew :entry:web:build --no-daemon

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertProcessor.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertProcessor.kt
@@ -1,0 +1,17 @@
+package com.pokit.alert.component
+
+import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.port.`in`.AlertUseCase
+import org.springframework.batch.item.ItemProcessor
+import org.springframework.stereotype.Component
+
+@Component
+class AlertProcessor(
+    private val alertUseCase: AlertUseCase,
+) : ItemProcessor<AlertBatch, AlertBatch> {
+
+    override fun process(alertBatch: AlertBatch): AlertBatch {
+        alertUseCase.sendMessage(alertBatch)
+        return alertBatch
+    }
+}

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertReader.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertReader.kt
@@ -1,0 +1,29 @@
+package com.pokit.alert.component
+
+import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.port.`in`.AlertUseCase
+import org.springframework.batch.item.ItemReader
+import org.springframework.stereotype.Component
+
+@Component
+class AlertReader(
+    private val alertUseCase: AlertUseCase,
+) : ItemReader<AlertBatch> {
+
+    private var currentPage: Int = 0
+    private val pageSize: Int = 50
+    private var alertBatchList: MutableList<AlertBatch> = mutableListOf()
+
+    override fun read(): AlertBatch? {
+        if (alertBatchList.isEmpty()) {
+            val alertBatches = alertUseCase.loadAllAlertBatch(currentPage++, pageSize)
+            alertBatchList.addAll(alertBatches)
+
+            if (alertBatchList.isEmpty()) {
+                return null
+            }
+        }
+
+        return alertBatchList.removeFirst()
+    }
+}

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertReader.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertReader.kt
@@ -1,6 +1,7 @@
 package com.pokit.alert.component
 
 import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.model.AlertBatchValue
 import com.pokit.alert.port.`in`.AlertUseCase
 import org.springframework.batch.item.ItemReader
 import org.springframework.stereotype.Component
@@ -11,12 +12,11 @@ class AlertReader(
 ) : ItemReader<AlertBatch> {
 
     private var currentPage: Int = 0
-    private val pageSize: Int = 50
     private var alertBatchList: MutableList<AlertBatch> = mutableListOf()
 
     override fun read(): AlertBatch? {
         if (alertBatchList.isEmpty()) {
-            val alertBatches = alertUseCase.loadAllAlertBatch(currentPage++, pageSize)
+            val alertBatches = alertUseCase.loadAllAlertBatch(currentPage++, AlertBatchValue.CHUNK_SIZE)
             alertBatchList.addAll(alertBatches)
 
             if (alertBatchList.isEmpty()) {

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertWriter.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/component/AlertWriter.kt
@@ -1,0 +1,19 @@
+package com.pokit.alert.component
+
+import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.port.`in`.AlertUseCase
+import org.springframework.batch.item.Chunk
+import org.springframework.batch.item.ItemWriter
+import org.springframework.stereotype.Component
+
+@Component
+class AlertWriter(
+    private val alertUseCase: AlertUseCase,
+) : ItemWriter<AlertBatch> {
+    override fun write(alertBatches: Chunk<out AlertBatch>) {
+        val batchIds = alertBatches.map { it.id }
+        val alertContents = alertUseCase.fetchAllAlertContent(batchIds)
+
+        alertUseCase.createAlerts(alertContents)
+    }
+}

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/job/SendAlertConfig.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/job/SendAlertConfig.kt
@@ -6,6 +6,7 @@ import com.pokit.alert.component.AlertProcessor
 import com.pokit.alert.component.AlertReader
 import com.pokit.alert.component.AlertWriter
 import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.model.AlertBatchValue
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.transaction.PlatformTransactionManager
@@ -31,7 +32,7 @@ class SendAlertConfig(
     @Bean
     fun sendAlertStep() = batch {
         step("sendAlertStep") {
-            chunk(50, transactionManager, fun SimpleStepBuilderDsl<AlertBatch, AlertBatch>.() {
+            chunk(AlertBatchValue.CHUNK_SIZE, transactionManager, fun SimpleStepBuilderDsl<AlertBatch, AlertBatch>.() {
                 reader(alertReader)
                 processor(alertProcessor)
                 writer(alertWriter)

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/job/SendAlertConfig.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/job/SendAlertConfig.kt
@@ -1,0 +1,42 @@
+package com.pokit.alert.job
+
+import com.navercorp.spring.batch.plus.kotlin.configuration.BatchDsl
+import com.navercorp.spring.batch.plus.kotlin.configuration.step.SimpleStepBuilderDsl
+import com.pokit.alert.component.AlertProcessor
+import com.pokit.alert.component.AlertReader
+import com.pokit.alert.component.AlertWriter
+import com.pokit.alert.model.AlertBatch
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.TransactionDefinition
+import org.springframework.transaction.interceptor.DefaultTransactionAttribute
+
+
+@Configuration
+class SendAlertConfig(
+    private val transactionManager: PlatformTransactionManager,
+    private val batch: BatchDsl,
+    private val alertReader: AlertReader,
+    private val alertProcessor: AlertProcessor,
+    private val alertWriter: AlertWriter
+) {
+    @Bean(name = ["sendAlertJob"])
+    fun sendAlertJob() = batch {
+        job("sendAlertJob") {
+            step(sendAlertStep())
+        }
+    }
+
+    @Bean
+    fun sendAlertStep() = batch {
+        step("sendAlertStep") {
+            chunk(50, transactionManager, fun SimpleStepBuilderDsl<AlertBatch, AlertBatch>.() {
+                reader(alertReader)
+                processor(alertProcessor)
+                writer(alertWriter)
+                transactionAttribute(DefaultTransactionAttribute(TransactionDefinition.PROPAGATION_NOT_SUPPORTED))
+            })
+        }
+    }
+}

--- a/adapters/in-batch/src/main/kotlin/com/pokit/alert/scheduler/SendAlertScheduler.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/alert/scheduler/SendAlertScheduler.kt
@@ -1,4 +1,4 @@
-package com.pokit.remind.scheduler
+package com.pokit.alert.scheduler
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.batch.core.Job
@@ -9,24 +9,24 @@ import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 
 @Component
-class DailyContentUpdateScheduler(
+class SendAlertScheduler(
     private val jobLauncher: JobLauncher,
-    @Qualifier("updateDailyContentJob") private val updateDailyContent: Job,
+    @Qualifier("sendAlertJob") private val sendAlertJob: Job
 ) {
     private val logger = KotlinLogging.logger { }
 
     companion object {
-        private const val 매일_자정 = "0 0 0 * * *"
+        private const val 매일_오전_8시 = "0 0 8 * * *"
     }
 
-    @Scheduled(cron = 매일_자정)
-    fun updateDailyContent() {
+    @Scheduled(cron = 매일_오전_8시)
+    fun sendAlert() {
         val jobParameters = JobParametersBuilder()
             .addLong("run.id", System.currentTimeMillis())
             .toJobParameters()
 
-        logger.info { "[CONTENT BATCH] start daily content update job" }
-        jobLauncher.run(updateDailyContent, jobParameters)
-        logger.info { "[CONTENT BATCH] end daily content update job" }
+        logger.info { "[ALERT BATCH] start daily send alert job" }
+        jobLauncher.run(sendAlertJob, jobParameters)
+        logger.info { "[ALERT BATCH] end daily send alert job" }
     }
 }

--- a/adapters/in-batch/src/main/kotlin/com/pokit/config/SchedulerConfig.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/config/SchedulerConfig.kt
@@ -1,0 +1,24 @@
+package com.pokit.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.TaskScheduler
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler
+
+@Configuration
+@EnableScheduling
+class SchedulerConfig {
+    companion object {
+        private const val POOL_SIZE = 3
+    }
+
+    @Bean("schedulerTask")
+    fun taskScheduler(): TaskScheduler {
+        val executor = ThreadPoolTaskScheduler()
+        executor.poolSize = POOL_SIZE
+        executor.threadNamePrefix = "scheduler-thread-"
+        executor.initialize()
+        return executor
+    }
+}

--- a/adapters/in-batch/src/main/kotlin/com/pokit/remind/job/DailyContentConfig.kt
+++ b/adapters/in-batch/src/main/kotlin/com/pokit/remind/job/DailyContentConfig.kt
@@ -18,7 +18,7 @@ class DailyContentConfig(
     private val batch: BatchDsl,
 ) {
 
-    @Bean
+    @Bean(name = ["updateDailyContentJob"])
     fun updateDailyContentJob(): Job = batch {
         job("updateDailyContentJob") {
             step(deleteAllStep()) {

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertAdapter.kt
@@ -2,6 +2,8 @@ package com.pokit.out.persistence.alert.impl
 
 import com.pokit.alert.model.Alert
 import com.pokit.alert.port.out.AlertPort
+import com.pokit.out.persistence.alert.persist.AlertEntity
+import com.pokit.out.persistence.alert.persist.AlertJdbcRepository
 import com.pokit.out.persistence.alert.persist.AlertRepository
 import com.pokit.out.persistence.alert.persist.toDomain
 import org.springframework.data.domain.Pageable
@@ -11,7 +13,8 @@ import org.springframework.stereotype.Repository
 
 @Repository
 class AlertAdapter(
-    private val alertRepository: AlertRepository
+    private val alertRepository: AlertRepository,
+    private val alertJdbcRepository: AlertJdbcRepository
 ) : AlertPort {
     override fun loadAllByUserId(userId: Long, pageable: Pageable): Slice<Alert> {
         return alertRepository.findAllByUserIdAndDeleted(userId, false, pageable)
@@ -26,6 +29,13 @@ class AlertAdapter(
     override fun delete(alert: Alert) {
         alertRepository.findByIdOrNull(alert.id)
             ?.delete()
+    }
+
+    override fun persistAlerts(alerts: List<Alert>) {
+        val alertEntities = alerts.map {
+            AlertEntity.of(it)
+        }
+        alertJdbcRepository.bulkInsert(alertEntities)
     }
 
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertBatchAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertBatchAdapter.kt
@@ -1,0 +1,18 @@
+package com.pokit.out.persistence.alert.impl
+
+import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.port.out.AlertBatchPort
+import com.pokit.out.persistence.alert.persist.AlertBatchRepository
+import com.pokit.out.persistence.alert.persist.toDomain
+import org.springframework.stereotype.Repository
+import java.time.LocalDate
+
+@Repository
+class AlertBatchAdapter(
+    private val alertBatchRepository: AlertBatchRepository
+) : AlertBatchPort{
+    override fun loadAllByShouldBeSentAt(now: LocalDate): List<AlertBatch> {
+        return alertBatchRepository.findAllByShouldBeSentAtAfterAndSent(now, false)
+            .map { it.toDomain() }
+    }
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertBatchAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertBatchAdapter.kt
@@ -2,6 +2,7 @@ package com.pokit.out.persistence.alert.impl
 
 import com.pokit.alert.model.AlertBatch
 import com.pokit.alert.port.out.AlertBatchPort
+import com.pokit.out.persistence.alert.persist.AlertBatchEntity
 import com.pokit.out.persistence.alert.persist.AlertBatchRepository
 import com.pokit.out.persistence.alert.persist.toDomain
 import org.springframework.data.domain.Page
@@ -22,5 +23,15 @@ class AlertBatchAdapter(
     override fun send(alertBatch: AlertBatch) {
         alertBatchRepository.findByIdOrNull(alertBatch.id)
             ?.sent()
+    }
+
+    override fun loadByUserIdAndDate(userId: Long, date: LocalDate): AlertBatch? {
+        return alertBatchRepository.findByUserIdAndShouldBeSentAtAndSent(userId, date, false)
+            ?.run { toDomain() }
+    }
+
+    override fun persist(alertBatch: AlertBatch): AlertBatch {
+        val alertBatchEntity = AlertBatchEntity.of(alertBatch)
+        return alertBatchRepository.save(alertBatchEntity).toDomain()
     }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertBatchAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertBatchAdapter.kt
@@ -4,15 +4,23 @@ import com.pokit.alert.model.AlertBatch
 import com.pokit.alert.port.out.AlertBatchPort
 import com.pokit.out.persistence.alert.persist.AlertBatchRepository
 import com.pokit.out.persistence.alert.persist.toDomain
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import java.time.LocalDate
 
 @Repository
 class AlertBatchAdapter(
     private val alertBatchRepository: AlertBatchRepository
-) : AlertBatchPort{
-    override fun loadAllByShouldBeSentAt(now: LocalDate): List<AlertBatch> {
-        return alertBatchRepository.findAllByShouldBeSentAtAfterAndSent(now, false)
+) : AlertBatchPort {
+    override fun loadAllByShouldBeSentAt(now: LocalDate, pageable: Pageable): Page<AlertBatch> {
+        return alertBatchRepository.findAllByShouldBeSentAtAfterAndSent(now, false, pageable)
             .map { it.toDomain() }
+    }
+
+    override fun send(alertBatch: AlertBatch) {
+        alertBatchRepository.findByIdOrNull(alertBatch.id)
+            ?.sent()
     }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertContentAdapter.kt
@@ -11,11 +11,11 @@ class AlertContentAdapter(
     private val alertContentRepository: AlertContentRepository
 ) : AlertContentPort {
     override fun loadAllInAlertBatchIds(ids: List<Long>): List<AlertContent> {
-        return alertContentRepository.findAllByAlertBatchIdInAndDeleted(ids, false)
+        return alertContentRepository.findAllByAlertBatchIdIn(ids)
             .map { it.toDomain() }
     }
 
     override fun deleteAll(ids: List<Long>) {
-        alertContentRepository.deleteAllInIds(ids)
+        alertContentRepository.deleteAllByIdInBatch(ids)
     }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertContentAdapter.kt
@@ -1,0 +1,21 @@
+package com.pokit.out.persistence.alert.impl
+
+import com.pokit.alert.model.AlertContent
+import com.pokit.alert.port.out.AlertContentPort
+import com.pokit.out.persistence.alert.persist.AlertContentRepository
+import com.pokit.out.persistence.alert.persist.toDomain
+import org.springframework.stereotype.Repository
+
+@Repository
+class AlertContentAdapter(
+    private val alertContentRepository: AlertContentRepository
+) : AlertContentPort {
+    override fun loadAllInAlertBatchIds(ids: List<Long>): List<AlertContent> {
+        return alertContentRepository.findAllByAlertBatchIdInAndDeleted(ids, false)
+            .map { it.toDomain() }
+    }
+
+    override fun deleteAll(ids: List<Long>) {
+        alertContentRepository.deleteAllInIds(ids)
+    }
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/impl/AlertContentAdapter.kt
@@ -2,6 +2,7 @@ package com.pokit.out.persistence.alert.impl
 
 import com.pokit.alert.model.AlertContent
 import com.pokit.alert.port.out.AlertContentPort
+import com.pokit.out.persistence.alert.persist.AlertContentEntity
 import com.pokit.out.persistence.alert.persist.AlertContentRepository
 import com.pokit.out.persistence.alert.persist.toDomain
 import org.springframework.stereotype.Repository
@@ -17,5 +18,10 @@ class AlertContentAdapter(
 
     override fun deleteAll(ids: List<Long>) {
         alertContentRepository.deleteAllByIdInBatch(ids)
+    }
+
+    override fun persist(alertContent: AlertContent): AlertContent {
+        val alertContentEntity = AlertContentEntity.of(alertContent)
+        return alertContentRepository.save(alertContentEntity).toDomain()
     }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchEntity.kt
@@ -35,6 +35,7 @@ class AlertBatchEntity(
 }
 
 fun AlertBatchEntity.toDomain() = AlertBatch(
+    id = this.id,
     userId = this.userId,
     shouldBeSentAt = this.shouldBeSentAt
 )

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchEntity.kt
@@ -33,3 +33,8 @@ class AlertBatchEntity(
         )
     }
 }
+
+fun AlertBatchEntity.toDomain() = AlertBatch(
+    userId = this.userId,
+    shouldBeSentAt = this.shouldBeSentAt
+)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchRepository.kt
@@ -1,8 +1,10 @@
 package com.pokit.out.persistence.alert.persist
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDate
 
 interface AlertBatchRepository : JpaRepository<AlertBatchEntity, Long> {
-    fun findAllByShouldBeSentAtAfterAndSent(now: LocalDate, send: Boolean): List<AlertBatchEntity>
+    fun findAllByShouldBeSentAtAfterAndSent(now: LocalDate, send: Boolean, pageable: Pageable): Page<AlertBatchEntity>
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchRepository.kt
@@ -7,4 +7,6 @@ import java.time.LocalDate
 
 interface AlertBatchRepository : JpaRepository<AlertBatchEntity, Long> {
     fun findAllByShouldBeSentAtAfterAndSent(now: LocalDate, send: Boolean, pageable: Pageable): Page<AlertBatchEntity>
+
+    fun findByUserIdAndShouldBeSentAtAndSent(userId: Long, date: LocalDate, sent: Boolean): AlertBatchEntity?
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertBatchRepository.kt
@@ -1,0 +1,8 @@
+package com.pokit.out.persistence.alert.persist
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDate
+
+interface AlertBatchRepository : JpaRepository<AlertBatchEntity, Long> {
+    fun findAllByShouldBeSentAtAfterAndSent(now: LocalDate, send: Boolean): List<AlertBatchEntity>
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentEntity.kt
@@ -15,20 +15,41 @@ class AlertContentEntity(
     @Column(name = "alert_batch_id")
     val alertBatchId: Long,
 
+    @Column(name = "user_id")
+    val userId: Long,
+
     @Column(name = "content_id")
     val contentId: Long,
 
+    @Column(name = "content_thumb_nail")
+    val contentThumbNail: String,
+
+    @Column(name = "title")
+    val title: String,
+
     @Column(name = "is_deleted")
-    var delete: Boolean = false
+    var deleted: Boolean = false
 ) : BaseEntity() {
     fun delete() {
-        this.delete = true
+        this.deleted = true
     }
 
     companion object {
         fun of(alertContent: AlertContent) = AlertContentEntity(
             alertBatchId = alertContent.alertBatchId,
-            contentId = alertContent.contentId
+            userId = alertContent.userId,
+            contentId = alertContent.contentId,
+            contentThumbNail = alertContent.contentThumbNail,
+            title = alertContent.title
         )
     }
 }
+
+fun AlertContentEntity.toDomain() = AlertContent(
+    id = this.id,
+    alertBatchId = this.alertBatchId,
+    userId = this.userId,
+    contentId = this.contentId,
+    contentThumbNail = this.contentThumbNail,
+    title = this.title
+)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentEntity.kt
@@ -15,32 +15,14 @@ class AlertContentEntity(
     @Column(name = "alert_batch_id")
     val alertBatchId: Long,
 
-    @Column(name = "user_id")
-    val userId: Long,
-
     @Column(name = "content_id")
     val contentId: Long,
-
-    @Column(name = "content_thumb_nail")
-    val contentThumbNail: String,
-
-    @Column(name = "title")
-    val title: String,
-
-    @Column(name = "is_deleted")
-    var deleted: Boolean = false
 ) : BaseEntity() {
-    fun delete() {
-        this.deleted = true
-    }
 
     companion object {
         fun of(alertContent: AlertContent) = AlertContentEntity(
             alertBatchId = alertContent.alertBatchId,
-            userId = alertContent.userId,
             contentId = alertContent.contentId,
-            contentThumbNail = alertContent.contentThumbNail,
-            title = alertContent.title
         )
     }
 }
@@ -48,8 +30,5 @@ class AlertContentEntity(
 fun AlertContentEntity.toDomain() = AlertContent(
     id = this.id,
     alertBatchId = this.alertBatchId,
-    userId = this.userId,
     contentId = this.contentId,
-    contentThumbNail = this.contentThumbNail,
-    title = this.title
 )

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentRepository.kt
@@ -1,0 +1,18 @@
+package com.pokit.out.persistence.alert.persist
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+interface AlertContentRepository : JpaRepository<AlertContentEntity, Long> {
+    fun findAllByAlertBatchIdInAndDeleted(ids: List<Long>, deleted: Boolean): List<AlertContentEntity>
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+        update AlertContentEntity ac set ac.deleted = true
+        where ac.id in :ids
+        """
+    )
+    fun deleteAllInIds(ids: List<Long>)
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertContentRepository.kt
@@ -1,18 +1,7 @@
 package com.pokit.out.persistence.alert.persist
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
 
 interface AlertContentRepository : JpaRepository<AlertContentEntity, Long> {
-    fun findAllByAlertBatchIdInAndDeleted(ids: List<Long>, deleted: Boolean): List<AlertContentEntity>
-
-    @Modifying(clearAutomatically = true)
-    @Query(
-        """
-        update AlertContentEntity ac set ac.deleted = true
-        where ac.id in :ids
-        """
-    )
-    fun deleteAllInIds(ids: List<Long>)
+    fun findAllByAlertBatchIdIn(ids: List<Long>): List<AlertContentEntity>
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertJdbcRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertJdbcRepository.kt
@@ -1,0 +1,5 @@
+package com.pokit.out.persistence.alert.persist
+
+interface AlertJdbcRepository {
+    fun bulkInsert(alertEntities: List<AlertEntity>)
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertJdbcRepositoryImpl.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/alert/persist/AlertJdbcRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.pokit.out.persistence.alert.persist
+
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.stereotype.Repository
+
+@Repository
+class AlertJdbcRepositoryImpl(
+    private val jdbcTemplate: JdbcTemplate
+) : AlertJdbcRepository {
+    override fun bulkInsert(alertEntities: List<AlertEntity>) {
+        val sql = """
+            INSERT INTO alert (
+                user_id, content_id, content_thumb_nail
+                , title, is_deleted, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+        """.trimIndent()
+
+
+        val batchArgs = alertEntities.map { alert ->
+            arrayOf(
+                alert.userId,
+                alert.contentId,
+                alert.contentThumbNail,
+                alert.title,
+                alert.deleted
+            )
+        }
+
+        jdbcTemplate.batchUpdate(sql, batchArgs)
+    }
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
@@ -5,6 +5,7 @@ import com.pokit.content.dto.request.ContentSearchCondition
 import com.pokit.content.dto.response.ContentsResult
 import com.pokit.content.dto.response.SharedContentResult
 import com.pokit.content.model.Content
+import com.pokit.content.model.ContentWithUser
 import com.pokit.content.port.out.ContentPort
 import com.pokit.log.model.LogType
 import com.pokit.out.persistence.bookmark.persist.QBookmarkEntity.bookmarkEntity
@@ -187,6 +188,10 @@ class ContentAdapter(
         }
 
         contentRepository.bulkInsert(targetContentEntities)
+    }
+
+    override fun loadByContentIdsWithUser(contetIds: List<Long>): List<ContentWithUser> {
+        return contentRepository.findByIdInWithUser(contetIds)
     }
 
     override fun loadByContentIds(contentIds: List<Long>): List<Content> =

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentJdbcRepositoryImpl.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentJdbcRepositoryImpl.kt
@@ -14,6 +14,7 @@ class ContentJdbcRepositoryImpl(
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
         """.trimIndent()
 
+
         val batchArgs = contentEntities.map { content ->
             arrayOf(
                 content.categoryId,

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentRepository.kt
@@ -1,5 +1,6 @@
 package com.pokit.out.persistence.content.persist
 
+import com.pokit.content.model.ContentWithUser
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -40,4 +41,12 @@ interface ContentRepository : JpaRepository<ContentEntity, Long>, ContentJdbcRep
     """
     )
     fun countByUserId(userId: Long): Int
+
+    @Query("""
+        select new com.pokit.content.model.ContentWithUser(c.id, u.id, c.title, c.thumbNail) from ContentEntity c
+        join CategoryEntity ca on ca.id = c.categoryId
+        join UserEntity u on u.id = ca.userId
+        where c.id in :ids
+    """)
+    fun findByIdInWithUser(ids: List<Long>): List<ContentWithUser>
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/FcmTokenAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/FcmTokenAdapter.kt
@@ -15,4 +15,9 @@ class FcmTokenAdapter(
         val fcmTokenEntity = FcmTokenEntity.of(fcmToken)
         return fcmTokenRepository.save(fcmTokenEntity).toDomain()
     }
+
+    override fun loadByUserId(userId: Long): List<FcmToken> {
+        return fcmTokenRepository.findByUserId(userId)
+            .map { it.toDomain() }
+    }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/FcmTokenRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/FcmTokenRepository.kt
@@ -3,4 +3,5 @@ package com.pokit.out.persistence.user.persist
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface FcmTokenRepository : JpaRepository<FcmTokenEntity, Long> {
+    fun findByUserId(userId: Long): List<FcmTokenEntity>
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/event/AlertEvent.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/event/AlertEvent.kt
@@ -1,0 +1,41 @@
+package com.pokit.alert.port.event
+
+import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.model.AlertContent
+import com.pokit.alert.model.CreateAlertRequest
+import com.pokit.alert.port.out.AlertBatchPort
+import com.pokit.alert.port.out.AlertContentPort
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+import java.time.LocalDate
+import java.util.function.Supplier
+
+@Component
+class AlertEventHandler(
+    private val now: Supplier<LocalDate>,
+    private val alertBatchPort: AlertBatchPort,
+    private val alertContentPort: AlertContentPort,
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    fun createAlert(request: CreateAlertRequest) {
+        val alertBatch = alertBatchPort.loadByUserIdAndDate(request.userId, now.get().plusDays(7))
+            ?: createAlertBatch(request.userId)
+        val alertContent = AlertContent(
+            alertBatchId = alertBatch.id,
+            contentId = request.contetId
+        )
+        alertContentPort.persist(alertContent)
+    }
+
+    private fun createAlertBatch(userId: Long): AlertBatch {
+        val alertBatch = AlertBatch(
+            userId = userId,
+            shouldBeSentAt = now.get().plusDays(7)
+        )
+        return alertBatchPort.persist(alertBatch)
+    }
+}

--- a/application/src/main/kotlin/com/pokit/alert/port/in/AlertUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/in/AlertUseCase.kt
@@ -2,6 +2,7 @@ package com.pokit.alert.port.`in`
 
 import com.pokit.alert.dto.response.AlertsResponse
 import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.model.AlertContent
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -10,5 +11,11 @@ interface AlertUseCase {
 
     fun delete(userId: Long, alertId: Long)
 
-    fun loadAllAlertBatch(): List<AlertBatch>
+    fun loadAllAlertBatch(currentPageNum: Int, pageSize: Int): List<AlertBatch>
+
+    fun sendMessage(alertBatch: AlertBatch)
+
+    fun fetchAllAlertContent(ids: List<Long>): List<AlertContent>
+
+    fun createAlerts(alertContents: List<AlertContent>)
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/in/AlertUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/in/AlertUseCase.kt
@@ -1,6 +1,7 @@
 package com.pokit.alert.port.`in`
 
 import com.pokit.alert.dto.response.AlertsResponse
+import com.pokit.alert.model.AlertBatch
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -8,4 +9,6 @@ interface AlertUseCase {
     fun getAlerts(userId: Long, pageable: Pageable): Slice<AlertsResponse>
 
     fun delete(userId: Long, alertId: Long)
+
+    fun loadAllAlertBatch(): List<AlertBatch>
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertBatchPort.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertBatchPort.kt
@@ -9,4 +9,8 @@ interface AlertBatchPort {
     fun loadAllByShouldBeSentAt(now: LocalDate, pageable: Pageable): Page<AlertBatch>
 
     fun send(alertBatch: AlertBatch)
+
+    fun loadByUserIdAndDate(userId: Long, date: LocalDate): AlertBatch?
+
+    fun persist(alertBatch: AlertBatch): AlertBatch
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertBatchPort.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertBatchPort.kt
@@ -1,8 +1,12 @@
 package com.pokit.alert.port.out
 
 import com.pokit.alert.model.AlertBatch
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import java.time.LocalDate
 
 interface AlertBatchPort {
-    fun loadAllByShouldBeSentAt(now: LocalDate): List<AlertBatch>
+    fun loadAllByShouldBeSentAt(now: LocalDate, pageable: Pageable): Page<AlertBatch>
+
+    fun send(alertBatch: AlertBatch)
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertBatchPort.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertBatchPort.kt
@@ -1,0 +1,8 @@
+package com.pokit.alert.port.out
+
+import com.pokit.alert.model.AlertBatch
+import java.time.LocalDate
+
+interface AlertBatchPort {
+    fun loadAllByShouldBeSentAt(now: LocalDate): List<AlertBatch>
+}

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertContentPort.kt
@@ -1,0 +1,9 @@
+package com.pokit.alert.port.out
+
+import com.pokit.alert.model.AlertContent
+
+interface AlertContentPort {
+    fun loadAllInAlertBatchIds(ids: List<Long>): List<AlertContent>
+
+    fun deleteAll(ids: List<Long>)
+}

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertContentPort.kt
@@ -6,4 +6,6 @@ interface AlertContentPort {
     fun loadAllInAlertBatchIds(ids: List<Long>): List<AlertContent>
 
     fun deleteAll(ids: List<Long>)
+
+    fun persist(alertContent: AlertContent): AlertContent
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertPort.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertPort.kt
@@ -10,4 +10,6 @@ interface AlertPort {
     fun loadByIdAndUserId(id: Long, userId: Long): Alert?
 
     fun delete(alert: Alert)
+
+    fun persistAlerts(alerts: List<Alert>)
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/out/AlertSender.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/out/AlertSender.kt
@@ -1,7 +1,5 @@
 package com.pokit.alert.port.out
 
-import com.pokit.alert.model.AlertBatch
-
 interface AlertSender {
     fun send(tokens: List<String>)
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/service/AlertService.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/service/AlertService.kt
@@ -3,11 +3,17 @@ package com.pokit.alert.port.service
 import com.pokit.alert.dto.response.AlertsResponse
 import com.pokit.alert.dto.response.toAlertsResponse
 import com.pokit.alert.exception.AlertErrorCode
+import com.pokit.alert.model.Alert
 import com.pokit.alert.model.AlertBatch
+import com.pokit.alert.model.AlertContent
 import com.pokit.alert.port.`in`.AlertUseCase
 import com.pokit.alert.port.out.AlertBatchPort
+import com.pokit.alert.port.out.AlertContentPort
 import com.pokit.alert.port.out.AlertPort
+import com.pokit.alert.port.out.AlertSender
 import com.pokit.common.exception.NotFoundCustomException
+import com.pokit.user.port.out.FcmTokenPort
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.stereotype.Service
@@ -23,6 +29,9 @@ class AlertService(
     private val now: Supplier<LocalDateTime>,
     private val alertPort: AlertPort,
     private val alertBatchPort: AlertBatchPort,
+    private val alertSender: AlertSender,
+    private val fcmTokenPort: FcmTokenPort,
+    private val alertContentPort: AlertContentPort
 ) : AlertUseCase {
     override fun getAlerts(userId: Long, pageable: Pageable): Slice<AlertsResponse> {
         val nowDay = now.get().toLocalDate()
@@ -41,7 +50,34 @@ class AlertService(
         alertPort.delete(alert)
     }
 
-    override fun loadAllAlertBatch(): List<AlertBatch> {
-        return alertBatchPort.loadAllByShouldBeSentAt(now.get().toLocalDate())
+    override fun loadAllAlertBatch(currentPageNum: Int, pageSize: Int): List<AlertBatch> {
+        val pageable = PageRequest.of(currentPageNum, pageSize)
+        return alertBatchPort.loadAllByShouldBeSentAt(now.get().toLocalDate(), pageable).content
+    }
+
+    @Transactional
+    override fun sendMessage(alertBatch: AlertBatch) {
+        val tokens = fcmTokenPort.loadByUserId(alertBatch.userId)
+            .map { it.token }
+        alertBatchPort.send(alertBatch)
+        alertSender.send(tokens)
+    }
+
+    override fun fetchAllAlertContent(ids: List<Long>): List<AlertContent> {
+        return alertContentPort.loadAllInAlertBatchIds(ids)
+    }
+
+    @Transactional
+    override fun createAlerts(alertContents: List<AlertContent>) {
+        val alerts = alertContents.map {
+            Alert(
+                userId = it.userId,
+                contentId = it.contentId,
+                contentThumbNail = it.contentThumbNail,
+                title = it.title
+            )
+        }
+        alertPort.persistAlerts(alerts)
+        alertContentPort.deleteAll(alertContents.map { it.id })
     }
 }

--- a/application/src/main/kotlin/com/pokit/alert/port/service/AlertService.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/service/AlertService.kt
@@ -12,6 +12,8 @@ import com.pokit.alert.port.out.AlertContentPort
 import com.pokit.alert.port.out.AlertPort
 import com.pokit.alert.port.out.AlertSender
 import com.pokit.common.exception.NotFoundCustomException
+import com.pokit.content.model.ContentDefault
+import com.pokit.content.port.out.ContentPort
 import com.pokit.user.port.out.FcmTokenPort
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -31,7 +33,8 @@ class AlertService(
     private val alertBatchPort: AlertBatchPort,
     private val alertSender: AlertSender,
     private val fcmTokenPort: FcmTokenPort,
-    private val alertContentPort: AlertContentPort
+    private val alertContentPort: AlertContentPort,
+    private val contentPort: ContentPort
 ) : AlertUseCase {
     override fun getAlerts(userId: Long, pageable: Pageable): Slice<AlertsResponse> {
         val nowDay = now.get().toLocalDate()
@@ -69,11 +72,12 @@ class AlertService(
 
     @Transactional
     override fun createAlerts(alertContents: List<AlertContent>) {
-        val alerts = alertContents.map {
+        val contents = contentPort.loadByContentIdsWithUser(alertContents.map { it.contentId })
+        val alerts = contents.map {
             Alert(
                 userId = it.userId,
                 contentId = it.contentId,
-                contentThumbNail = it.contentThumbNail,
+                contentThumbNail = it.thumbNail ?: ContentDefault.THUMB_NAIL,
                 title = it.title
             )
         }

--- a/application/src/main/kotlin/com/pokit/alert/port/service/AlertService.kt
+++ b/application/src/main/kotlin/com/pokit/alert/port/service/AlertService.kt
@@ -3,7 +3,9 @@ package com.pokit.alert.port.service
 import com.pokit.alert.dto.response.AlertsResponse
 import com.pokit.alert.dto.response.toAlertsResponse
 import com.pokit.alert.exception.AlertErrorCode
+import com.pokit.alert.model.AlertBatch
 import com.pokit.alert.port.`in`.AlertUseCase
+import com.pokit.alert.port.out.AlertBatchPort
 import com.pokit.alert.port.out.AlertPort
 import com.pokit.common.exception.NotFoundCustomException
 import org.springframework.data.domain.Pageable
@@ -19,7 +21,8 @@ import kotlin.math.abs
 @Transactional(readOnly = true)
 class AlertService(
     private val now: Supplier<LocalDateTime>,
-    private val alertPort: AlertPort
+    private val alertPort: AlertPort,
+    private val alertBatchPort: AlertBatchPort,
 ) : AlertUseCase {
     override fun getAlerts(userId: Long, pageable: Pageable): Slice<AlertsResponse> {
         val nowDay = now.get().toLocalDate()
@@ -36,5 +39,9 @@ class AlertService(
         val alert = alertPort.loadByIdAndUserId(alertId, userId)
             ?: throw NotFoundCustomException(AlertErrorCode.NOT_FOUND_ALERT)
         alertPort.delete(alert)
+    }
+
+    override fun loadAllAlertBatch(): List<AlertBatch> {
+        return alertBatchPort.loadAllByShouldBeSentAt(now.get().toLocalDate())
     }
 }

--- a/application/src/main/kotlin/com/pokit/config/TimeConfig.kt
+++ b/application/src/main/kotlin/com/pokit/config/TimeConfig.kt
@@ -2,6 +2,7 @@ package com.pokit.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.function.Supplier
 
@@ -11,5 +12,10 @@ class TimeConfig {
     @Bean("nowTimeSupplier")
     fun nowTimeSupplier(): Supplier<LocalDateTime> {
         return Supplier { LocalDateTime.now() }
+    }
+
+    @Bean("nowDateSupplier")
+    fun nowDateSupplier(): Supplier<LocalDate> {
+        return Supplier { LocalDate.now() }
     }
 }

--- a/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
@@ -5,6 +5,7 @@ import com.pokit.content.dto.response.ContentsResult
 import com.pokit.content.dto.request.ContentSearchCondition
 import com.pokit.content.dto.response.SharedContentResult
 import com.pokit.content.model.Content
+import com.pokit.content.model.ContentWithUser
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 
@@ -44,4 +45,6 @@ interface ContentPort {
     ): Slice<SharedContentResult>
 
     fun duplicateContent(originCategoryId: Long, targetCategoryId: Long)
+
+    fun loadByContentIdsWithUser(contetIds: List<Long>): List<ContentWithUser>
 }

--- a/application/src/main/kotlin/com/pokit/user/port/out/FcmTokenPort.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/FcmTokenPort.kt
@@ -4,4 +4,6 @@ import com.pokit.user.model.FcmToken
 
 interface FcmTokenPort {
     fun persist(fcmToken: FcmToken): FcmToken
+
+    fun loadByUserId(userId: Long): List<FcmToken>
 }

--- a/application/src/test/kotlin/com/pokit/alert/port/service/AlertServiceTest.kt
+++ b/application/src/test/kotlin/com/pokit/alert/port/service/AlertServiceTest.kt
@@ -1,6 +1,7 @@
 package com.pokit.alert.port.service
 
 import com.pokit.alert.AlertFixure
+import com.pokit.alert.port.out.AlertBatchPort
 import com.pokit.alert.port.out.AlertPort
 import com.pokit.user.UserFixture
 import io.kotest.core.spec.style.BehaviorSpec
@@ -15,8 +16,8 @@ import java.util.function.Supplier
 class AlertServiceTest : BehaviorSpec({
     val alertPort = mockk<AlertPort>()
     val now = mockk<Supplier<LocalDateTime>>()
-
-    val alertService = AlertService(now, alertPort)
+    val alertBatchPort = mockk<AlertBatchPort>()
+    val alertService = AlertService(now, alertPort, alertBatchPort)
 
     Given("알림 관련 요청이 들어올 때") {
         val nowTime = LocalDateTime.of(2024, 8, 15, 15, 30)

--- a/application/src/test/kotlin/com/pokit/user/port/service/UserServiceTest.kt
+++ b/application/src/test/kotlin/com/pokit/user/port/service/UserServiceTest.kt
@@ -10,6 +10,7 @@ import com.pokit.token.model.AuthPlatform
 import com.pokit.user.UserFixture
 import com.pokit.user.dto.request.UpdateNicknameRequest
 import com.pokit.user.model.User
+import com.pokit.user.port.out.FcmTokenPort
 import com.pokit.user.port.out.UserPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -21,7 +22,8 @@ class UserServiceTest : BehaviorSpec({
     val userPort = mockk<UserPort>()
     val categoryPort = mockk<CategoryPort>()
     val categoryImagePort = mockk<CategoryImagePort>()
-    val userService = UserService(userPort, categoryPort, categoryImagePort)
+    val fcmTokenPort = mockk<FcmTokenPort>()
+    val userService = UserService(userPort, categoryPort, categoryImagePort, fcmTokenPort)
     Given("회원을 등록할 때") {
         val user = UserFixture.getUser()
         val invalidUser = UserFixture.getInvalidUser()

--- a/domain/src/main/kotlin/com/pokit/alert/model/AlertBatch.kt
+++ b/domain/src/main/kotlin/com/pokit/alert/model/AlertBatch.kt
@@ -11,3 +11,8 @@ data class AlertBatch(
 object AlertBatchValue {
     const val CHUNK_SIZE = 50
 }
+
+data class CreateAlertRequest(
+    val userId: Long,
+    val contetId: Long
+)

--- a/domain/src/main/kotlin/com/pokit/alert/model/AlertBatch.kt
+++ b/domain/src/main/kotlin/com/pokit/alert/model/AlertBatch.kt
@@ -7,3 +7,7 @@ data class AlertBatch(
     val userId: Long,
     val shouldBeSentAt: LocalDate,
 )
+
+object AlertBatchValue {
+    const val CHUNK_SIZE = 50
+}

--- a/domain/src/main/kotlin/com/pokit/alert/model/AlertBatch.kt
+++ b/domain/src/main/kotlin/com/pokit/alert/model/AlertBatch.kt
@@ -3,6 +3,7 @@ package com.pokit.alert.model
 import java.time.LocalDate
 
 data class AlertBatch(
+    val id: Long = 0L,
     val userId: Long,
     val shouldBeSentAt: LocalDate,
 )

--- a/domain/src/main/kotlin/com/pokit/alert/model/AlertContent.kt
+++ b/domain/src/main/kotlin/com/pokit/alert/model/AlertContent.kt
@@ -3,8 +3,5 @@ package com.pokit.alert.model
 data class AlertContent(
     val id: Long = 0L,
     val alertBatchId: Long,
-    val userId: Long,
     val contentId: Long,
-    val contentThumbNail: String,
-    val title: String
 )

--- a/domain/src/main/kotlin/com/pokit/alert/model/AlertContent.kt
+++ b/domain/src/main/kotlin/com/pokit/alert/model/AlertContent.kt
@@ -1,6 +1,10 @@
 package com.pokit.alert.model
 
 data class AlertContent(
+    val id: Long = 0L,
     val alertBatchId: Long,
-    val contentId: Long
+    val userId: Long,
+    val contentId: Long,
+    val contentThumbNail: String,
+    val title: String
 )

--- a/domain/src/main/kotlin/com/pokit/content/model/Content.kt
+++ b/domain/src/main/kotlin/com/pokit/content/model/Content.kt
@@ -52,3 +52,10 @@ data class CategoryInfo(
 object ContentDefault {
     const val THUMB_NAIL = "https://pokit-storage.s3.ap-northeast-2.amazonaws.com/logo/pokit.png"
 }
+
+data class ContentWithUser(
+    val contentId: Long,
+    val userId: Long,
+    var title: String,
+    var thumbNail: String?
+)

--- a/entry/batch/src/main/kotlin/com/pokit/BatchApplication.kt
+++ b/entry/batch/src/main/kotlin/com/pokit/BatchApplication.kt
@@ -11,6 +11,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 class BatchApplication
 
 fun main(args: Array<String>) {
-    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence")
+    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-batch")
     runApplication<BatchApplication>(*args)
 }

--- a/entry/batch/src/main/kotlin/com/pokit/BatchApplication.kt
+++ b/entry/batch/src/main/kotlin/com/pokit/BatchApplication.kt
@@ -11,6 +11,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 class BatchApplication
 
 fun main(args: Array<String>) {
-    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-batch")
+    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-batch, application-entry")
     runApplication<BatchApplication>(*args)
 }

--- a/entry/batch/src/main/kotlin/com/pokit/BatchApplication.kt
+++ b/entry/batch/src/main/kotlin/com/pokit/BatchApplication.kt
@@ -11,6 +11,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 class BatchApplication
 
 fun main(args: Array<String>) {
-    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-batch, application-entry")
+    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-batch")
     runApplication<BatchApplication>(*args)
 }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #116 

### 📍 리뷰 포인트

- 배치 비즈니스 로직

### 📝 참고사항(Optional)

- 배치 - 컨텐츠 매핑 테이블 AlertContent에 컨텐츠 관련 필드들을 넣었습니다
    - 배치 id랑 컨텐츠 id만 있으면 컨텐츠 조회해서 알림 생성하는 과정이 번거로워서.. 컨텐츠 조회를 안해도 되는 방향으로 했는데 요것도 피드백 주세요..
```sql
alter table alert_content
    add column user_id bigint not null,
    add column content_thumb_nail varchar(255),
    add column title varchar(255);
```
- multi job 관련 설정으로 배포 스크립트에 in-batch yml추가했고 노션에도 있습미다.
- 리뷰하기 넘 많을 것 같아서 로직 간단 요약 첨부...
### Item Reader

- sent false, 전송시점 된 배치 알림 엔티티 loadAll
- return AlertBatch

### Item Processor

- AlertBatch를 통해 알림 전송
- AlertBatch sent 필드 업데이트 false → true
- return AlertBatch

### Item Writer

- AlertBatch 전달받음(청크 단위 50)
- AlertBatch ids로 AlertContent 전체 조회
- Alert 생성 후 bulk insert
- AlertContent 삭제