### PR TITLE
[feat #161] 안읽음, 즐겨찾기 개수 조회 API

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/content/RemindController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/RemindController.kt
@@ -4,7 +4,9 @@ import com.pokit.auth.model.PrincipalUser
 import com.pokit.common.dto.SliceResponseDto
 import com.pokit.common.wrapper.ResponseWrapper.wrapOk
 import com.pokit.common.wrapper.ResponseWrapper.wrapSlice
+import com.pokit.content.dto.response.BookmarkCountResponse
 import com.pokit.content.dto.response.RemindContentResponse
+import com.pokit.content.dto.response.UnreadCountResponse
 import com.pokit.content.dto.response.toResponse
 import com.pokit.content.port.`in`.ContentUseCase
 import com.pokit.content.port.`in`.DailyContentUseCase
@@ -65,4 +67,23 @@ class RemindController(
             .map { it.toResponse() }
             .wrapOk()
 
+    @GetMapping("/unread/count")
+    @Operation(summary = "안읽음 컨텐츠 개수 조회 API")
+    fun getUnreadCount(
+        @AuthenticationPrincipal user: PrincipalUser
+    ): ResponseEntity<UnreadCountResponse> {
+        val unreadCount = contentUseCase.getUnreadCount(user.id)
+        return UnreadCountResponse(unreadCount)
+            .wrapOk()
+    }
+
+    @GetMapping("/bookmark/count")
+    @Operation(summary = "즐겨찾기 컨텐츠 개수 조회 API")
+    fun getBookmarkCount(
+        @AuthenticationPrincipal user: PrincipalUser
+    ): ResponseEntity<BookmarkCountResponse> {
+        val bookmarkCount = contentUseCase.getBookmarkCount(user.id)
+        return BookmarkCountResponse(bookmarkCount)
+            .wrapOk()
+    }
 }

--- a/adapters/in-web/src/main/kotlin/com/pokit/content/dto/response/RemindContentResponse.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/dto/response/RemindContentResponse.kt
@@ -16,6 +16,14 @@ data class RemindContentResponse(
     val thumbNail: String,
 )
 
+data class UnreadCountResponse(
+    val unreadContentCount: Int
+)
+
+data class BookmarkCountResponse(
+    val bookmarkContentCount: Int
+)
+
 fun RemindContentResult.toResponse(): RemindContentResponse {
     val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
 

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/bookmark/persist/BookMarkRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/bookmark/persist/BookMarkRepository.kt
@@ -14,4 +14,6 @@ interface BookMarkRepository : JpaRepository<BookmarkEntity, Long> {
     fun findByUserIdAndDeleted(userId: Long, deleted: Boolean, pageable: Pageable): Slice<BookmarkEntity>
 
     fun existsByContentIdAndUserIdAndDeleted(contentId: Long, userId: Long, deleted: Boolean): Boolean
+
+    fun countByUserIdAndDeleted(userId: Long, deleted: Boolean): Int
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentCountAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentCountAdapter.kt
@@ -1,0 +1,32 @@
+package com.pokit.out.persistence.content.impl
+
+import com.pokit.content.port.out.ContentCountPort
+import com.pokit.log.model.LogType
+import com.pokit.out.persistence.bookmark.persist.BookMarkRepository
+import com.pokit.out.persistence.category.persist.QCategoryEntity.categoryEntity
+import com.pokit.out.persistence.content.persist.QContentEntity.contentEntity
+import com.pokit.out.persistence.log.persist.QUserLogEntity.userLogEntity
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.stereotype.Repository
+
+@Repository
+class ContentCountAdapter(
+    private val queryFactory: JPAQueryFactory,
+    private val bookMarkRepository: BookMarkRepository
+) : ContentCountPort {
+    override fun getUnreadCount(userId: Long): Int {
+        return queryFactory.select(contentEntity.count())
+            .from(contentEntity)
+            .leftJoin(userLogEntity).on(userLogEntity.contentId.eq(contentEntity.id))
+            .join(categoryEntity).on(categoryEntity.id.eq(contentEntity.categoryId))
+            .where(
+                categoryEntity.userId.eq(userId),
+                contentEntity.deleted.isFalse,
+                userLogEntity.id.isNull.or(userLogEntity.type.ne(LogType.READ))
+            )
+            .fetchFirst()!!.toInt()
+    }
+
+    override fun getBookmarkContent(userId: Long) =
+        bookMarkRepository.countByUserIdAndDeleted(userId, false)
+}

--- a/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
@@ -36,4 +36,8 @@ interface ContentUseCase {
     fun getBookmarkContents(userId: Long, pageable: Pageable): Slice<RemindContentResult>
 
     fun getUnreadContents(userId: Long, pageable: Pageable): Slice<RemindContentResult>
+
+    fun getUnreadCount(userId: Long): Int
+
+    fun getBookmarkCount(userId: Long): Int
 }

--- a/application/src/main/kotlin/com/pokit/content/port/out/ContentCountPort.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/out/ContentCountPort.kt
@@ -1,0 +1,7 @@
+package com.pokit.content.port.out
+
+interface ContentCountPort {
+    fun getUnreadCount(userId: Long): Int
+
+    fun getBookmarkContent(userId: Long): Int
+}

--- a/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
@@ -18,6 +18,7 @@ import com.pokit.content.dto.response.*
 import com.pokit.content.exception.ContentErrorCode
 import com.pokit.content.model.Content
 import com.pokit.content.port.`in`.ContentUseCase
+import com.pokit.content.port.out.ContentCountPort
 import com.pokit.content.port.out.ContentPort
 import com.pokit.log.model.LogType
 import com.pokit.log.model.UserLog
@@ -37,7 +38,8 @@ class ContentService(
     private val bookMarkPort: BookmarkPort,
     private val categoryPort: CategoryPort,
     private val userLogPort: UserLogPort,
-    private val publisher: ApplicationEventPublisher
+    private val publisher: ApplicationEventPublisher,
+    private val contentCountPort: ContentCountPort
 ) : ContentUseCase {
     companion object {
         private const val MIN_CONTENT_COUNT = 3
@@ -154,6 +156,12 @@ class ContentService(
 
         return SliceImpl(remindContents, pageable, unreadContents.hasNext())
     }
+
+    override fun getUnreadCount(userId: Long) =
+        contentCountPort.getUnreadCount(userId)
+
+    override fun getBookmarkCount(userId: Long) =
+        contentCountPort.getBookmarkContent(userId)
 
     private fun verifyContent(userId: Long, contentId: Long): Content {
         return contentPort.loadByUserIdAndId(userId, contentId)


### PR DESCRIPTION
### ⛏ 이슈 번호

close #161 

### 📍 리뷰 포인트

- 개수 조회 쿼리
- 포트 분리

### 📝 참고사항(Optional)

- 카운트 포트를 따로 분리했는데 어케 생각하시나요?? ContentAdapter 코드가 좀 길어서 분리했습ㄴ다.
- 아니면 기존 안읽음, 즐겨찾기 목록 조회 api에 개수 필드만 따로 추가할 지
