### PR TITLE
[edit #167] 회원 저장 로직 수정

### DIFF
--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
@@ -15,7 +15,7 @@ class UserEntity(
     val id: Long = 0L,
 
     @Column(name = "email")
-    val email: String = "EMAIL",
+    val email: String = "EMAIL@EMAIL.COM",
 
     @Column(name = "role")
     @Enumerated(EnumType.STRING)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
@@ -15,14 +15,14 @@ class UserEntity(
     val id: Long = 0L,
 
     @Column(name = "email")
-    val email: String,
+    val email: String = "EMAIL",
 
     @Column(name = "role")
     @Enumerated(EnumType.STRING)
     val role: Role,
 
     @Column(name = "nickname")
-    var nickname: String = email,
+    var nickname: String = "NOT_REGISTERED",
 
     @Column(name = "auth_platform")
     @Enumerated(EnumType.STRING)

--- a/application/src/main/kotlin/com/pokit/auth/port/service/AuthService.kt
+++ b/application/src/main/kotlin/com/pokit/auth/port/service/AuthService.kt
@@ -65,7 +65,6 @@ class AuthService(
 
     private fun createUser(userInfo: UserInfo): User {
         val user = User(
-            email = userInfo.email!!, // 존재하지 않았던 유저면 이메일 항상 존재
             role = Role.USER,
             authPlatform = userInfo.authPlatform,
             sub = userInfo.sub

--- a/application/src/test/kotlin/com/pokit/auth/port/service/AuthServiceTest.kt
+++ b/application/src/test/kotlin/com/pokit/auth/port/service/AuthServiceTest.kt
@@ -35,7 +35,7 @@ class AuthServiceTest : BehaviorSpec({
 
         every { googleApiClient.getUserInfo(request.idToken) } returns userInfo
         every {
-            userPort.loadByEmailAndAuthPlatform(userInfo.email, AuthPlatform.of(request.authPlatform))
+            userPort.loadByEmailAndAuthPlatform(userInfo.email!!, AuthPlatform.of(request.authPlatform))
         } returns user
         every { userPort.loadById(user.id) } returns user
         every { tokenProvider.createToken(user.id) } returns token

--- a/domain/src/main/kotlin/com/pokit/user/model/User.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/User.kt
@@ -7,7 +7,7 @@ import java.util.regex.Pattern
 
 data class User(
     val id: Long = 0L,
-    val email: String = "EMAIL",
+    val email: String = "EMAIL@EMAIL.COM",
     val role: Role,
     var nickName: String = "NOT_REGISTERED",
     val authPlatform: AuthPlatform,

--- a/domain/src/main/kotlin/com/pokit/user/model/User.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/User.kt
@@ -7,9 +7,9 @@ import java.util.regex.Pattern
 
 data class User(
     val id: Long = 0L,
-    val email: String,
+    val email: String = "EMAIL",
     val role: Role,
-    var nickName: String = email,
+    var nickName: String = "NOT_REGISTERED",
     val authPlatform: AuthPlatform,
     var registered: Boolean = false,
     var sub: String?


### PR DESCRIPTION
### ⛏ 이슈 번호

close #167 

### 📍 리뷰 포인트

### 📝 참고사항(Optional)

- email 저장 할 필요가 없어서 수정
- 기존에 저장된 User들을 email로 찾아서 email 필드 자체는 현재 삭제 불가해서 생성자 기본값 세팅
