### PR TITLE
[feat #183] 프로필 수정 API

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
@@ -4,10 +4,7 @@ import com.pokit.auth.config.ErrorOperation
 import com.pokit.auth.model.PrincipalUser
 import com.pokit.auth.model.toDomain
 import com.pokit.common.wrapper.ResponseWrapper.wrapOk
-import com.pokit.user.dto.request.ApiCreateFcmTokenRequest
-import com.pokit.user.dto.request.ApiSignUpRequest
-import com.pokit.user.dto.request.ApiUpdateNicknameRequest
-import com.pokit.user.dto.request.toDto
+import com.pokit.user.dto.request.*
 import com.pokit.user.dto.response.CheckDuplicateNicknameResponse
 import com.pokit.user.dto.response.InterestTypeResponse
 import com.pokit.user.dto.response.UserResponse
@@ -87,6 +84,17 @@ class UserController(
         @AuthenticationPrincipal user: PrincipalUser
     ): ResponseEntity<UserResponse> {
         return userUseCase.getUserInfo(user.id)
+            .toResponse()
+            .wrapOk()
+    }
+
+    @PutMapping
+    @Operation(summary = "유저 프로필 수정 API")
+    fun updateProfile(
+        @AuthenticationPrincipal user: PrincipalUser,
+        @RequestBody request: UpdateProfileRequest
+    ): ResponseEntity<UserResponse> {
+        return userUseCase.updateProfile(user.id, request.toDto())
             .toResponse()
             .wrapOk()
     }

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/dto/request/UpdateProfileRequest.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/dto/request/UpdateProfileRequest.kt
@@ -1,0 +1,16 @@
+package com.pokit.user.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class UpdateProfileRequest(
+    val profileImageId: Int,
+    @field:NotBlank(message = "닉네임은 필수값입니다.")
+    @field:Size(max = 10, message = "닉네임은 10자 이하만 가능합니다.")
+    val nickname: String
+)
+
+internal fun UpdateProfileRequest.toDto() = UserCommand(
+    profileImageId = this.profileImageId,
+    nickname = this.nickname
+)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserAdapter.kt
@@ -27,6 +27,10 @@ class UserAdapter(
         ?.run { toDomain() }
 
     override fun checkByNickname(nickname: String) = userRepository.existsByNickname(nickname)
+
+    override fun checkByNickname(nickname: String, userId: Long) =
+        userRepository.existsByNicknameAndIdNot(nickname, userId)
+
     override fun delete(user: User) {
         userRepository.findByIdOrNull(user.id)
             ?.delete()

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserImageAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/UserImageAdapter.kt
@@ -1,0 +1,23 @@
+package com.pokit.out.persistence.user.impl
+
+import com.pokit.out.persistence.user.persist.UserImageRepository
+import com.pokit.out.persistence.user.persist.toDomain
+import com.pokit.user.model.UserImage
+import com.pokit.user.port.out.UserImagePort
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserImageAdapter(
+    private val userImageRepository: UserImageRepository
+) : UserImagePort {
+    override fun loadById(id: Int): UserImage? {
+        return userImageRepository.findByIdOrNull(id)
+            ?.toDomain()
+    }
+
+    override fun loadAll(): List<UserImage> {
+        return userImageRepository.findAll()
+            .map { it.toDomain() }
+    }
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserEntity.kt
@@ -35,7 +35,11 @@ class UserEntity(
     var registered: Boolean,
 
     @Column(name = "sub")
-    var sub: String?
+    var sub: String?,
+
+    @OneToOne
+    @JoinColumn(name = "image_id", foreignKey = ForeignKey(ConstraintMode.NO_CONSTRAINT))
+    val image: UserImageEntity?
 ) : BaseEntity() {
     fun delete() {
         this.deleted = true
@@ -50,7 +54,8 @@ class UserEntity(
                 nickname = user.nickName,
                 authPlatform = user.authPlatform,
                 registered = user.registered,
-                sub = user.sub
+                sub = user.sub,
+                image = user.image?.let { UserImageEntity.of(it) }
             )
     }
 }
@@ -62,5 +67,6 @@ fun UserEntity.toDomain() = User(
     nickName = this.nickname,
     authPlatform = this.authPlatform,
     registered = this.registered,
-    sub = this.sub
+    sub = this.sub,
+    image = this.image?.toDomain()
 )

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserImageEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserImageEntity.kt
@@ -1,0 +1,26 @@
+package com.pokit.out.persistence.user.persist
+
+import com.pokit.user.model.UserImage
+import jakarta.persistence.*
+
+@Table(name = "USER_IMAGE")
+@Entity
+class UserImageEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    val id: Int = 0,
+
+    @Column(name = "url")
+    val url: String
+) {
+    companion object {
+        fun of(userImage: UserImage) =
+            UserImageEntity(
+                id = userImage.id,
+                url = userImage.url
+            )
+    }
+}
+
+fun UserImageEntity.toDomain() = UserImage(this.id, this.url)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserImageRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserImageRepository.kt
@@ -1,0 +1,6 @@
+package com.pokit.out.persistence.user.persist
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserImageRepository : JpaRepository<UserImageEntity, Int> {
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/UserRepository.kt
@@ -8,6 +8,8 @@ interface UserRepository : JpaRepository<UserEntity, Long> {
 
     fun existsByNickname(nickname: String): Boolean
 
+    fun existsByNicknameAndIdNot(nickname: String, userId: Long): Boolean
+
     fun findByIdAndDeleted(id: Long, deleted: Boolean): UserEntity?
 
     fun findByDeleted(deleted: Boolean): List<UserEntity>

--- a/application/src/main/kotlin/com/pokit/user/port/in/UserUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/in/UserUseCase.kt
@@ -3,6 +3,7 @@ package com.pokit.user.port.`in`
 import com.pokit.user.dto.request.CreateFcmTokenRequest
 import com.pokit.user.dto.request.SignUpRequest
 import com.pokit.user.dto.request.UpdateNicknameRequest
+import com.pokit.user.dto.request.UserCommand
 import com.pokit.user.model.FcmToken
 import com.pokit.user.model.User
 
@@ -18,4 +19,6 @@ interface UserUseCase {
     fun createFcmToken(userId: Long, request: CreateFcmTokenRequest): FcmToken
 
     fun getUserInfo(userId: Long): User
+
+    fun updateProfile(userId: Long, command: UserCommand): User
 }

--- a/application/src/main/kotlin/com/pokit/user/port/out/UserImagePort.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/UserImagePort.kt
@@ -1,0 +1,9 @@
+package com.pokit.user.port.out
+
+import com.pokit.user.model.UserImage
+
+interface UserImagePort {
+    fun loadById(id: Int): UserImage?
+
+    fun loadAll(): List<UserImage>
+}

--- a/application/src/main/kotlin/com/pokit/user/port/out/UserPort.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/UserPort.kt
@@ -12,6 +12,8 @@ interface UserPort {
 
     fun checkByNickname(nickname: String): Boolean
 
+    fun checkByNickname(nickname: String, userId: Long): Boolean
+
     fun delete(user: User)
 
     fun loadAllIds(): List<Long>

--- a/application/src/test/kotlin/com/pokit/user/port/service/UserServiceTest.kt
+++ b/application/src/test/kotlin/com/pokit/user/port/service/UserServiceTest.kt
@@ -10,7 +10,9 @@ import com.pokit.token.model.AuthPlatform
 import com.pokit.user.UserFixture
 import com.pokit.user.dto.request.UpdateNicknameRequest
 import com.pokit.user.model.User
+import com.pokit.user.model.UserImage
 import com.pokit.user.port.out.FcmTokenPort
+import com.pokit.user.port.out.UserImagePort
 import com.pokit.user.port.out.UserPort
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
@@ -23,12 +25,14 @@ class UserServiceTest : BehaviorSpec({
     val categoryPort = mockk<CategoryPort>()
     val categoryImagePort = mockk<CategoryImagePort>()
     val fcmTokenPort = mockk<FcmTokenPort>()
-    val userService = UserService(userPort, categoryPort, categoryImagePort, fcmTokenPort)
+    val userImagePort = mockk<UserImagePort>()
+    val userService = UserService(userPort, categoryPort, categoryImagePort, fcmTokenPort, userImagePort)
     Given("회원을 등록할 때") {
         val user = UserFixture.getUser()
         val invalidUser = UserFixture.getInvalidUser()
         val request = UserFixture.getSignUpRequest()
-        val modifieUser = User(user.id, user.email, user.role, request.nickName, AuthPlatform.GOOGLE, sub = "sub")
+        val userImage = UserImage(1, "url")
+        val modifieUser = User(user.id, user.email, user.role, request.nickName, AuthPlatform.GOOGLE, sub = "sub", image = userImage)
         val image = CategoryImage(1, "https://www.image.com")
         val unCategorized = CategoryFixture.getUnCategorized(user.id, image)
 

--- a/domain/src/main/kotlin/com/pokit/user/dto/request/UserCommand.kt
+++ b/domain/src/main/kotlin/com/pokit/user/dto/request/UserCommand.kt
@@ -1,0 +1,6 @@
+package com.pokit.user.dto.request
+
+data class UserCommand(
+    val profileImageId: Int,
+    val nickname: String
+)

--- a/domain/src/main/kotlin/com/pokit/user/exception/UserErrorCode.kt
+++ b/domain/src/main/kotlin/com/pokit/user/exception/UserErrorCode.kt
@@ -10,5 +10,6 @@ enum class UserErrorCode(
     INVALID_INTEREST_TYPE("관심사가 잘못되었습니다.", "U_002"),
     NOT_FOUND_USER("존재하지 않는 회원입니다.", "U_003"),
     ALREADY_EXISTS_NICKNAME("이미 존재하는 닉네임입니다.", "U_004"),
-    ALREADY_REGISTERED("이미 회원가입 한 유저입니다.", "U_005")
+    ALREADY_REGISTERED("이미 회원가입 한 유저입니다.", "U_005"),
+    NOT_FOUND_PROFILE_IMAGE("존재하지 않는 프로필 이미지입니다.", "U_006"),
 }

--- a/domain/src/main/kotlin/com/pokit/user/model/User.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/User.kt
@@ -12,7 +12,8 @@ data class User(
     var nickName: String = "NOT_REGISTERED",
     val authPlatform: AuthPlatform,
     var registered: Boolean = false,
-    var sub: String?
+    var sub: String?,
+    var image: UserImage? = null
 ) {
     fun register(nickName: String) {
         this.nickName = nickName
@@ -25,6 +26,11 @@ data class User(
 
     fun modifyNickname(nickName: String) {
         this.nickName = nickName
+    }
+
+    fun modifyProfile(image: UserImage, nickname: String) {
+        this.image = image
+        this.nickName = nickname
     }
 
     init {

--- a/domain/src/main/kotlin/com/pokit/user/model/UserImage.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/UserImage.kt
@@ -1,0 +1,6 @@
+package com.pokit.user.model
+
+data class UserImage(
+    val id: Int,
+    val url: String
+)


### PR DESCRIPTION
### ⛏ 이슈 번호

close #183 

### 📍 리뷰 포인트

- 프로필 수정 로직
- 기타 불필요 코드??

### 📝 참고사항(Optional)

- 프로필 기본이미지인 경우를 null로 했는데 다른 의견있다면 주십시오!
- 닉네임 중복체크 쿼리가 본인포함하여 검사해서 본인 제외한 쿼리 추가했어요
- 유저이미지 테이블, 유저테이블에 이미지id 필드 추가
```sql
create table user_image
(
    id  int auto_increment
        primary key,
    url varchar(255) null
);

alter table user add column image_id int;
```
