### PR TITLE
[feat #210] 포킷 상세조회 api 수정

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/content/dto/response/ContentsResponse.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/dto/response/ContentsResponse.kt
@@ -17,6 +17,7 @@ data class ContentsResponse(
     val thumbNail: String,
     val isFavorite: Boolean,
     val keyword: String,
+    val memoExists: Boolean,
 )
 
 fun ContentsResult.toResponse(): ContentsResponse {
@@ -35,5 +36,6 @@ fun ContentsResult.toResponse(): ContentsResponse {
         thumbNail = this.thumbNail,
         isFavorite = this.isFavorite,
         keyword = this.keyword,
+        memoExists = this.memoExists,
     )
 }

--- a/domain/src/main/kotlin/com/pokit/content/dto/response/ContentsResult.kt
+++ b/domain/src/main/kotlin/com/pokit/content/dto/response/ContentsResult.kt
@@ -17,7 +17,8 @@ data class ContentsResult(
     val isRead: Boolean,
     val thumbNail: String,
     val isFavorite: Boolean,
-    val keyword: String
+    val keyword: String,
+    val memoExists: Boolean,
 ) {
     companion object {
         fun of(
@@ -39,7 +40,8 @@ data class ContentsResult(
                 isRead = isRead > 0,
                 thumbNail = content.thumbNail ?: ContentDefault.THUMB_NAIL,
                 isFavorite = isFavorite > 0,
-                keyword = keyword
+                keyword = keyword,
+                memoExists = content.memo.isNotBlank(),
             )
         }
     }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #210 

### 📝 참고사항(Optional)

- 초대 된 User 조회는 api 따로
- 공개여부 필드도 추후 작업(쿼리 수정 필요)
