### PR TITLE
[fix #222] 포킷 복제 후 v2 api로 조회 시 안되는 버그 수정

### DIFF
--- a/application/src/main/kotlin/com/pokit/category/port/service/CategoryService.kt
+++ b/application/src/main/kotlin/com/pokit/category/port/service/CategoryService.kt
@@ -166,6 +166,13 @@ class CategoryService(
             ?: throw NotFoundCustomException(CategoryErrorCode.NOT_FOUND_CATEGORY_IMAGE))
         val newCategory = categoryPort.persist(originCategory.duplicate(categoryName, userId, categoryImage))
         contentPort.duplicateContent(originCategoryId, newCategory.categoryId)
+
+        val sharedCategory = SharedCategory(
+            userId = userId,
+            categoryId = newCategory.categoryId
+        )
+
+        sharedCategoryPort.persist(sharedCategory)
     }
 
     @Transactional


### PR DESCRIPTION
### ⛏ 이슈 번호

close #222 

### 📝 참고사항(Optional)

- sharedCategory 엔티티 저장 로직 한 줄 추가
