### PR TITLE
[feat #221] 포킷 목록 조회 api ver2 추가작업

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/category/v2/CategoryControllerV2.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/category/v2/CategoryControllerV2.kt
@@ -13,6 +13,7 @@ import com.pokit.common.dto.SliceResponseDto
 import com.pokit.common.wrapper.ResponseWrapper.wrapOk
 import com.pokit.common.wrapper.ResponseWrapper.wrapSlice
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.data.domain.Pageable
@@ -63,9 +64,11 @@ class CategoryControllerV2(
             sort = ["createdAt"],
             direction = Sort.Direction.DESC
         ) pageable: Pageable,
-        @RequestParam(defaultValue = "true") filterUncategorized: Boolean
+        @RequestParam(defaultValue = "true") filterUncategorized: Boolean,
+        @Parameter(description = "default는 false이고 즐겨찾기 포함 조회. true로 보내면 즐겨찾기 포킷이 제외됨")
+        @RequestParam(defaultValue = "false") filterFavorite: Boolean,
     ): ResponseEntity<SliceResponseDto<CategoriesResponse>> {
-        return categoryUseCase.getCategoriesV2(user.id, pageable, filterUncategorized)
+        return categoryUseCase.getCategoriesV2(user.id, pageable, filterUncategorized, filterFavorite)
             .wrapSlice()
             .wrapOk()
     }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/category/persist/CategoryEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/category/persist/CategoryEntity.kt
@@ -41,6 +41,9 @@ class CategoryEntity(
 
     @Column(name = "owner_id")
     var ownerId: Long,
+
+    @Column(name = "is_favorite")
+    val isFavorite: Boolean
 ) : BaseEntity() {
 
     @Column(name = "is_deleted")
@@ -62,6 +65,7 @@ class CategoryEntity(
                 isShared = category.isShared,
                 keyword = category.keyword,
                 ownerId = category.ownerId,
+                isFavorite = category.isFavorite,
             )
     }
 }
@@ -77,4 +81,5 @@ fun CategoryEntity.toDomain() = Category(
     isShared = this.isShared,
     keyword = this.keyword,
     ownerId = this.ownerId,
+    isFavorite = this.isFavorite,
 )

--- a/application/src/main/kotlin/com/pokit/category/port/in/CategoryUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/category/port/in/CategoryUseCase.kt
@@ -22,6 +22,6 @@ interface CategoryUseCase {
     fun acceptCategory(userId: Long, categoryId: Long)
     fun resignUser(userId: Long, categoryId: Long, resignUserId: Long)
     fun outCategory(userId: Long, categoryId: Long)
-    fun getCategoriesV2(userId: Long, pageable: Pageable, filterUncategorized: Boolean): Slice<CategoriesResponse>
+    fun getCategoriesV2(userId: Long, pageable: Pageable, filterUncategorized: Boolean, filterFavorite: Boolean): Slice<CategoriesResponse>
     fun getInvitedUsers(userId: Long, categoryId: Long): List<User>
 }

--- a/application/src/main/kotlin/com/pokit/category/port/service/CategoryService.kt
+++ b/application/src/main/kotlin/com/pokit/category/port/service/CategoryService.kt
@@ -5,6 +5,7 @@ import com.pokit.category.dto.CategoryCommand
 import com.pokit.category.dto.toCategoriesResponse
 import com.pokit.category.exception.CategoryErrorCode
 import com.pokit.category.model.*
+import com.pokit.category.model.CategoryStatus.FAVORITE
 import com.pokit.category.model.CategoryStatus.UNCATEGORIZED
 import com.pokit.category.port.`in`.CategoryUseCase
 import com.pokit.category.port.out.CategoryImagePort
@@ -103,7 +104,7 @@ class CategoryService(
             val contentCount = contentPort.fetchContentCountByCategoryId(category.categoryId)
             category.copy(contentCount = contentCount)
         }.map { category ->
-            category.toCategoriesResponse()
+            category.toCategoriesResponse(category.isFavorite)
         }
 
         val filteredCategories = if (filterUncategorized) {
@@ -220,16 +221,25 @@ class CategoryService(
         categoryPort.persist(category)
     }
 
-    override fun getCategoriesV2(userId: Long, pageable: Pageable, filterUncategorized: Boolean): Slice<CategoriesResponse> {
+    override fun getCategoriesV2(userId: Long, pageable: Pageable, filterUncategorized: Boolean, filterFavorite: Boolean): Slice<CategoriesResponse> {
         val sharedCategories = sharedCategoryPort.loadByUserId(userId)
         val categoryIds = sharedCategories.map { it.categoryId }
         val categoriesSlice = categoryPort.loadAllInId(categoryIds, pageable)
+
+        val bookmark = contentPort.loadBookmarkedContentsByUserId(userId, pageable)
+        val favoriteCategory = categoryPort.loadByNameAndUserId(FAVORITE.displayName, userId)
+        favoriteCategory!!.copy(contentCount = bookmark.size)
 
         val categories = categoriesSlice.content.map { category ->
             val contentCount = contentPort.fetchContentCountByCategoryId(category.categoryId)
             category.copy(contentCount = contentCount)
         }.map { category ->
-            category.toCategoriesResponse()
+            category.toCategoriesResponse(category.isFavorite)
+        }.toMutableList()
+
+        if (!filterFavorite) {
+            val favoriteResponse = favoriteCategory.toCategoriesResponse(favoriteCategory.isFavorite)
+            categories.add(0, favoriteResponse)
         }
 
         val filteredCategories = if (filterUncategorized) {

--- a/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
@@ -2,6 +2,7 @@ package com.pokit.user.port.service
 
 import com.pokit.category.exception.CategoryErrorCode
 import com.pokit.category.model.Category
+import com.pokit.category.model.CategoryStatus.FAVORITE
 import com.pokit.category.model.CategoryStatus.UNCATEGORIZED
 import com.pokit.category.model.OpenType
 import com.pokit.category.port.out.CategoryImagePort
@@ -61,6 +62,17 @@ class UserService(
             openType = OpenType.PRIVATE,
             keyword = InterestType.DEFAULT,
             ownerId = user.id,
+        )
+        categoryPort.persist(category)
+
+        Category(
+            userId = savedUser.id,
+            categoryName = FAVORITE.displayName,
+            categoryImage = image,
+            openType = OpenType.PRIVATE,
+            keyword = InterestType.DEFAULT,
+            ownerId = user.id,
+            isFavorite = true
         )
         categoryPort.persist(category)
 

--- a/domain/src/main/kotlin/com/pokit/category/dto/CategoriesResponse.kt
+++ b/domain/src/main/kotlin/com/pokit/category/dto/CategoriesResponse.kt
@@ -14,9 +14,10 @@ data class CategoriesResponse(
     val openType: String,
     val keywordType: String,
     val userCount: Int,
+    val isFavorite: Boolean,
 )
 
-fun Category.toCategoriesResponse(): CategoriesResponse {
+fun Category.toCategoriesResponse(isFavorite: Boolean): CategoriesResponse {
     val formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd")
 
     return CategoriesResponse(
@@ -29,5 +30,6 @@ fun Category.toCategoriesResponse(): CategoriesResponse {
         openType = this.openType.toString(),
         keywordType = this.keyword.kor,
         userCount = this.userCount,
+        isFavorite = isFavorite,
     )
 }

--- a/domain/src/main/kotlin/com/pokit/category/model/Category.kt
+++ b/domain/src/main/kotlin/com/pokit/category/model/Category.kt
@@ -16,6 +16,7 @@ data class Category(
     var isShared: Boolean = false,
     var keyword: InterestType,
     var ownerId: Long,
+    val isFavorite: Boolean = false,
 ) {
     fun update(command: CategoryCommand, categoryImage: CategoryImage) {
         this.categoryName = command.categoryName

--- a/domain/src/main/kotlin/com/pokit/category/model/CategoryStatus.kt
+++ b/domain/src/main/kotlin/com/pokit/category/model/CategoryStatus.kt
@@ -3,7 +3,8 @@ package com.pokit.category.model
 enum class CategoryStatus(
     val displayName: String
 ) {
-    UNCATEGORIZED("미분류")
+    UNCATEGORIZED("미분류"),
+    FAVORITE("즐겨찾기")
     ;
 
     companion object {


### PR DESCRIPTION
### ⛏ 이슈 번호

close #221 

### 📝 참고사항(Optional)

- 카테고리 필드에 즐겨찾기 여부 필드 추가
- 유저별로 즐겨찾기 카테고리 데이터 하나씩 삽입
- 회원가입 시 즐겨찾기 포킷 생성 로직 추가

```sql
alter table category add column is_favorite bit default false;
```

```sql
INSERT INTO category (
    image_id,
    is_deleted,
    created_at,
    updated_at,
    user_id,
    name,
    open_type,
    is_shared,
    user_count,
    keyword,
    owner_id,
    is_favorite
)
SELECT
    1 AS image_id,                          
    false AS is_deleted,                    
    NOW() AS created_at,                    
    NOW() AS updated_at,                    
    u.id AS user_id,                        
    '즐겨찾기' AS name,
    'PRIVATE' AS open_type,                 
    false AS is_shared,                     
    0 AS user_count,                        
    'DEFAULT' AS keyword,                   
    u.id AS owner_id,                       
    1 AS is_favorite                        
FROM
    user u;
```
