### PR TITLE
[feat #239] 관심사 수정 API 구현

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/UserController.kt
@@ -4,6 +4,7 @@ import com.pokit.auth.config.ErrorOperation
 import com.pokit.auth.model.PrincipalUser
 import com.pokit.auth.model.toDomain
 import com.pokit.common.wrapper.ResponseWrapper.wrapOk
+import com.pokit.common.wrapper.ResponseWrapper.wrapUnit
 import com.pokit.user.dto.request.*
 import com.pokit.user.dto.response.CheckDuplicateNicknameResponse
 import com.pokit.user.dto.response.InterestTypeResponse
@@ -125,5 +126,15 @@ class UserController(
     fun getProfileImage(): ResponseEntity<List<UserImage>> {
         return userUseCase.getProfileImages()
             .wrapOk()
+    }
+
+    @PutMapping("/myinterests")
+    @Operation(summary = "관심사 수정 API")
+    fun updateMyInterests(
+        @AuthenticationPrincipal user: PrincipalUser,
+        @Valid @RequestBody request: UpdateInterestRequest,
+    ): ResponseEntity<Unit> {
+        return userUseCase.updateMyInterests(user.id, request.interests)
+            .wrapUnit()
     }
 }

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/dto/request/UpdateInterestRequest.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/dto/request/UpdateInterestRequest.kt
@@ -1,0 +1,8 @@
+package com.pokit.user.dto.request
+
+import jakarta.validation.constraints.Size
+
+data class UpdateInterestRequest(
+    @Size(min = 1, max = 3, message = "최소 하나 이상, 세개 이하만 가능합니다.")
+    val interests: List<String>,
+)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/InterestAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/impl/InterestAdapter.kt
@@ -24,4 +24,8 @@ class InterestAdapter (
         return interestRepository.findAllByUserId(userId)
             .map { it.toDomain() }
     }
+
+    override fun deleteByUserId(userId: Long) {
+        interestRepository.deleteByUserId(userId)
+    }
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/InterestRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/user/persist/InterestRepository.kt
@@ -4,4 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface InterestRepository : JpaRepository<InterestEntity, Long> {
     fun findAllByUserId(userId: Long): List<InterestEntity>
+
+    fun deleteByUserId(userId: Long)
 }

--- a/application/src/main/kotlin/com/pokit/user/port/in/UserUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/in/UserUseCase.kt
@@ -29,4 +29,6 @@ interface UserUseCase {
     fun getProfile(userId: Long): User
 
     fun getProfileImages(): List<UserImage>
+
+    fun updateMyInterests(userId: Long, interests: List<String>)
 }

--- a/application/src/main/kotlin/com/pokit/user/port/out/InterestPort.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/InterestPort.kt
@@ -8,4 +8,6 @@ interface InterestPort {
     fun delete(interest: Interest)
 
     fun loadByUserId(userId: Long): List<Interest>
+
+    fun deleteByUserId(userId: Long)
 }

--- a/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
@@ -146,4 +146,13 @@ class UserService(
             ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_USER)
 
     override fun getProfileImages() = userImagePort.loadAll()
+
+    @Transactional
+    override fun updateMyInterests(userId: Long, interests: List<String>) {
+        interestPort.deleteByUserId(userId)
+        val interestTypes = interests.map { InterestType.of(it) }
+        interestTypes.forEach {
+            interestPort.persist(Interest(userId = userId, interestType = it))
+        }
+    }
 }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #239 

### 📝 참고사항(Optional)

- 유저 관심사 전부 삭제 후 새로 저장
