### PR TITLE
[feat #241] 신고하기 API 구현 

### DIFF
--- a/adapters/in-web/src/main/kotlin/com/pokit/content/ContentController.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/content/ContentController.kt
@@ -222,5 +222,14 @@ class ContentController(
 
     }
 
+    @PostMapping("/report/{contentId}")
+    @Operation(summary = "신고하기 API", description = "신고된 컨텐츠 반환")
+    fun reportContent(
+        @AuthenticationPrincipal user: PrincipalUser,
+        @PathVariable("contentId") contentId: Long,
+    ): ResponseEntity<Unit> {
+        return contentUseCase.report(user.id, contentId)
+            .wrapUnit()
+    }
 }
 

--- a/adapters/in-web/src/main/kotlin/com/pokit/user/dto/request/UpdateProfileRequest.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/user/dto/request/UpdateProfileRequest.kt
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Size
 
 data class UpdateProfileRequest(
-    val profileImageId: Int,
+    val profileImageId: Int?,
     @field:NotBlank(message = "닉네임은 필수값입니다.")
     @field:Size(max = 10, message = "닉네임은 10자 이하만 가능합니다.")
     val nickname: String

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
@@ -13,6 +13,7 @@ import com.pokit.out.persistence.category.persist.QCategoryEntity.categoryEntity
 import com.pokit.out.persistence.content.persist.ContentEntity
 import com.pokit.out.persistence.content.persist.ContentRepository
 import com.pokit.out.persistence.content.persist.QContentEntity.contentEntity
+import com.pokit.out.persistence.content.persist.QReportedContentEntity.reportedContentEntity
 import com.pokit.out.persistence.content.persist.toDomain
 import com.pokit.out.persistence.log.persist.QUserLogEntity.userLogEntity
 import com.pokit.user.model.InterestType
@@ -66,12 +67,13 @@ class ContentAdapter(
             .from(contentEntity)
             .leftJoin(userLogEntity).on(userLogEntity.contentId.eq(contentEntity.id))
             .join(categoryEntity).on(categoryEntity.id.eq(contentEntity.categoryId))
+            .leftJoin(reportedContentEntity).on(reportedContentEntity.contentId.eq(contentEntity.id))
             .leftJoin(bookmarkEntity).on(bookmarkEntity.contentId.eq(contentEntity.id).and(bookmarkEntity.deleted.isFalse))
 
         FavoriteOrNot(condition.favorites, query) // 북마크 조인 여부
 
         query.where(
-            categoryEntity.userId.eq(userId),
+            reportedContentEntity.id.isNull.or(reportedContentEntity.reporterId.ne(userId)),
             condition.categoryId?.let { categoryEntity.id.eq(it) },
             isUnread(condition.isRead),
             contentEntity.deleted.isFalse,
@@ -136,9 +138,10 @@ class ContentAdapter(
             .from(contentEntity)
             .leftJoin(userLogEntity).on(userLogEntity.contentId.eq(contentEntity.id))
             .join(categoryEntity).on(categoryEntity.id.eq(contentEntity.categoryId))
+            .leftJoin(reportedContentEntity).on(reportedContentEntity.contentId.eq(contentEntity.id))
             .leftJoin(bookmarkEntity).on(bookmarkEntity.contentId.eq(contentEntity.id).and(bookmarkEntity.deleted.isFalse))
             .where(
-                categoryEntity.userId.eq(userId),
+                reportedContentEntity.reporterId.ne(userId),
                 contentEntity.deleted.isFalse,
                 bookmarkEntity.deleted.isFalse,
             )
@@ -219,9 +222,10 @@ class ContentAdapter(
         val contents = queryFactory.select(contentEntity, categoryEntity.name, categoryEntity.keyword)
             .from(contentEntity)
             .join(categoryEntity).on(contentEntity.categoryId.eq(categoryEntity.id))
+            .leftJoin(reportedContentEntity).on(reportedContentEntity.contentId.eq(contentEntity.id))
             .where(
+                reportedContentEntity.reporterId.ne(userId),
                 categoryEntity.openType.eq(OpenType.PUBLIC),
-                categoryEntity.userId.ne(userId),
                 categoryEntity.keyword.`in`(searchKeywords),
                 categoryEntity.deleted.isFalse,
                 contentEntity.deleted.isFalse

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ReportedContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ReportedContentAdapter.kt
@@ -1,0 +1,23 @@
+package com.pokit.out.persistence.content.impl
+
+import com.pokit.content.model.ReportedContent
+import com.pokit.content.port.out.ReportedContentPort
+import com.pokit.out.persistence.content.persist.ReportedContentEntity
+import com.pokit.out.persistence.content.persist.ReportedContentRepository
+import com.pokit.out.persistence.content.persist.toDomain
+import org.springframework.stereotype.Repository
+
+@Repository
+class ReportedContentAdapter(
+    private val reportedContentRepository: ReportedContentRepository
+) : ReportedContentPort {
+    override fun persist(reportedContent: ReportedContent): ReportedContent {
+        return reportedContentRepository.save(ReportedContentEntity.of(reportedContent))
+            .toDomain()
+    }
+
+    override fun loadAllByReporterId(reporterId: Long): List<ReportedContent> {
+        return reportedContentRepository.findAllByReporterId(reporterId)
+            .map { it.toDomain() }
+    }
+}

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ReportedContentEntity.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ReportedContentEntity.kt
@@ -1,0 +1,41 @@
+package com.pokit.out.persistence.content.persist
+
+import com.pokit.content.model.ReportedContent
+import com.pokit.out.persistence.BaseEntity
+import jakarta.persistence.*
+
+@Table(name = "REPORTED_CONTENT")
+@Entity
+class ReportedContentEntity(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    var id: Long = 0L,
+
+    @Column(name = "reporter_id")
+    val reporterId: Long,
+
+    @Column(name = "content_id")
+    val contentId: Long,
+
+    @Column(name = "is_deleted")
+    var isDeleted: Boolean = false,
+) : BaseEntity() {
+    fun delete() {
+        this.isDeleted = true
+    }
+
+    companion object {
+        fun of(reportedContent: ReportedContent) = ReportedContentEntity(
+            id = reportedContent.id,
+            reporterId = reportedContent.reporterId,
+            contentId = reportedContent.contentId,
+        )
+    }
+}
+
+internal fun ReportedContentEntity.toDomain() = ReportedContent(
+    id = this.id,
+    reporterId = reporterId,
+    contentId = this.contentId,
+)

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ReportedContentRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ReportedContentRepository.kt
@@ -1,0 +1,7 @@
+package com.pokit.out.persistence.content.persist
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ReportedContentRepository : JpaRepository<ReportedContentEntity, Long> {
+    fun findAllByReporterId(reporterId: Long): List<ReportedContentEntity>
+}

--- a/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/in/ContentUseCase.kt
@@ -50,4 +50,6 @@ interface ContentUseCase {
     fun updateThumbnail(userId: Long, contentId: Long, thumbnail: String): Content
 
     fun getRecommendedContent(userId: Long, keyword: String?, pageable: Pageable): Slice<ContentsResult>
+
+    fun report(userId: Long, contentId: Long)
 }

--- a/application/src/main/kotlin/com/pokit/content/port/out/ReportedContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/out/ReportedContentPort.kt
@@ -1,0 +1,9 @@
+package com.pokit.content.port.out
+
+import com.pokit.content.model.ReportedContent
+
+interface ReportedContentPort {
+    fun persist(reportedContent: ReportedContent): ReportedContent
+
+    fun loadAllByReporterId(reporterId: Long): List<ReportedContent>
+}

--- a/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
@@ -19,9 +19,11 @@ import com.pokit.content.dto.request.toDomain
 import com.pokit.content.dto.response.*
 import com.pokit.content.exception.ContentErrorCode
 import com.pokit.content.model.Content
+import com.pokit.content.model.ReportedContent
 import com.pokit.content.port.`in`.ContentUseCase
 import com.pokit.content.port.out.ContentCountPort
 import com.pokit.content.port.out.ContentPort
+import com.pokit.content.port.out.ReportedContentPort
 import com.pokit.log.model.LogType
 import com.pokit.log.model.UserLog
 import com.pokit.log.port.out.UserLogPort
@@ -48,6 +50,7 @@ class ContentService(
     private val contentCountPort: ContentCountPort,
     private val interestPort: InterestPort,
     private val userPort: UserPort,
+    private val reportedContentPort: ReportedContentPort,
 ) : ContentUseCase {
     companion object {
         private const val MIN_CONTENT_COUNT = 3
@@ -210,6 +213,18 @@ class ContentService(
             it.interestType
         }
         return contentPort.loadAllByKeyword(userId, searchKeyword, pageable)
+    }
+
+    @Transactional
+    override fun report(userId: Long, contentId: Long) {
+        verifyContent(contentId)
+
+        val reportedContent = ReportedContent(
+            reporterId = userId,
+            contentId = contentId,
+        )
+
+        reportedContentPort.persist(reportedContent)
     }
 
     private fun verifyContent(contentId: Long): Content {

--- a/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
@@ -125,8 +125,10 @@ class UserService(
         val user = userPort.loadById(userId)
             ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_USER)
 
-        val image = userImagePort.loadById(command.profileImageId)
-            ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_PROFILE_IMAGE)
+        val image = command.profileImageId?.let {
+            userImagePort.loadById(it)
+                ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_PROFILE_IMAGE)
+        }
 
         val isDuplicate = userPort.checkByNickname(command.nickname, userId)
         if (isDuplicate) {

--- a/domain/src/main/kotlin/com/pokit/content/model/ReportedContent.kt
+++ b/domain/src/main/kotlin/com/pokit/content/model/ReportedContent.kt
@@ -1,0 +1,7 @@
+package com.pokit.content.model
+
+data class ReportedContent(
+    val id: Long = 0L,
+    val reporterId: Long,
+    val contentId: Long,
+)

--- a/domain/src/main/kotlin/com/pokit/user/dto/request/UserCommand.kt
+++ b/domain/src/main/kotlin/com/pokit/user/dto/request/UserCommand.kt
@@ -1,6 +1,6 @@
 package com.pokit.user.dto.request
 
 data class UserCommand(
-    val profileImageId: Int,
+    val profileImageId: Int?,
     val nickname: String
 )

--- a/domain/src/main/kotlin/com/pokit/user/model/User.kt
+++ b/domain/src/main/kotlin/com/pokit/user/model/User.kt
@@ -28,7 +28,7 @@ data class User(
         this.nickName = nickName
     }
 
-    fun modifyProfile(image: UserImage, nickname: String) {
+    fun modifyProfile(image: UserImage?, nickname: String) {
         this.image = image
         this.nickName = nickname
     }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #241 

### 📝 참고사항(Optional)

- 신고 컨텐츠 엔티티 생성
```sql
create table reported_content
(
    id          bigint auto_increment
        primary key,
    reporter_id bigint                              not null,
    content_id  bigint                              not null,
    is_deleted  bit       default b'0'              not null,
    created_at  timestamp default CURRENT_TIMESTAMP not null,
    updated_at  timestamp default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP
);

```

- 프로필 수정 관련 오류 수정
    - 이미지 id nullable 하게 수정
- 컨텐츠 조회 쿼리 수정(공유 컨텐츠 조회 안되는 문제 관련)
    - 카테고리의 user_id = 요청 user_id 조건 제거
