### PR TITLE
[fix #253] : 컨텐츠 검색 오류 수정

### DIFF
--- a/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/service/ContentService.kt
@@ -122,9 +122,7 @@ class ContentService(
         pageable: Pageable,
     ): Slice<ContentsResult> {
         val category = condition.categoryId?.let { verifyCategory(it) }
-            ?: throw NotFoundCustomException(CategoryErrorCode.NOT_FOUND_CATEGORY);
-        logger.info { "컨디션 Dto : $condition" }
-        if(category.categoryName == CategoryStatus.FAVORITE.displayName) {
+        if (category != null && category.categoryName == CategoryStatus.FAVORITE.displayName) {
             val contents = contentPort.loadBookmarkedContentsByUserId(userId, pageable)
             return contents
         }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #253 

### 📝 참고사항(Optional)

- 이전에 즐겨찾기 컨텐츠 개수 관련 버그 수정하다 생긴 버그
- 카테고리가 null일 때 에러 반환 x(로직 상 에러상황이 아님)
