### PR TITLE
[feat #262] 카테고리 삭제 시 관련 엔티티 삭제 기능

### DIFF
--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/bookmark/impl/BookMarkAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/bookmark/impl/BookMarkAdapter.kt
@@ -41,6 +41,10 @@ class BookMarkAdapter(
     override fun isBookmarked(contentId: Long, userId: Long): Boolean =
         bookMarkRepository.existsByContentIdAndUserIdAndDeleted(contentId, userId, false)
 
+    override fun deleteByContentIds(contentIds: List<Long>, userId: Long) {
+        bookMarkRepository.deleteByContentIdsAndUserId(contentIds, userId)
+    }
+
     override fun loadByUserId(userId: Long, pageable: Pageable): Slice<Bookmark> =
         bookMarkRepository.findByUserIdAndDeleted(userId, false, pageable)
             .map { it.toDomain() }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/bookmark/persist/BookMarkRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/bookmark/persist/BookMarkRepository.kt
@@ -3,6 +3,9 @@ package com.pokit.out.persistence.bookmark.persist
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface BookMarkRepository : JpaRepository<BookmarkEntity, Long>, BookmarkQuerydslRepository {
     fun findByContentIdAndUserIdAndDeleted(
@@ -16,4 +19,16 @@ interface BookMarkRepository : JpaRepository<BookmarkEntity, Long>, BookmarkQuer
     fun existsByContentIdAndUserIdAndDeleted(contentId: Long, userId: Long, deleted: Boolean): Boolean
 
     fun countByUserIdAndDeleted(userId: Long, deleted: Boolean): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+            update BookmarkEntity b set b.deleted = true
+            where b.contentId in :contentIds and b.userId = :userId and b.deleted = false
+        """
+    )
+    fun deleteByContentIdsAndUserId(
+        @Param("contentIds") contentIds: List<Long>,
+        @Param("userId") userId: Long
+    )
 }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/impl/ContentAdapter.kt
@@ -259,6 +259,10 @@ class ContentAdapter(
         return contentRepository.findByIdOrNull(id)?.toDomain()
     }
 
+    override fun deleteByCategoryId(categoryId: Long) {
+        contentRepository.deleteByCategoryId(categoryId)
+    }
+
     override fun loadByContentIds(contentIds: List<Long>): List<Content> =
         contentRepository.findByIdIn(contentIds)
             .map { it.toDomain() }

--- a/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentRepository.kt
+++ b/adapters/out-persistence/src/main/kotlin/com/pokit/out/persistence/content/persist/ContentRepository.kt
@@ -87,4 +87,13 @@ interface ContentRepository : JpaRepository<ContentEntity, Long>, ContentJdbcRep
         @Param("contentIds") contentIds: List<Long>,
         @Param("categoryId") categoryId: Long
     )
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        """
+        update ContentEntity c set c.deleted = true
+        where c.categoryId = :categoryId
+    """
+    )
+    fun deleteByCategoryId(categoryId: Long)
 }

--- a/application/src/main/kotlin/com/pokit/bookmark/port/out/BookmarkPort.kt
+++ b/application/src/main/kotlin/com/pokit/bookmark/port/out/BookmarkPort.kt
@@ -14,4 +14,6 @@ interface BookmarkPort {
     fun loadByUserId(userId: Long, pageable: Pageable): Slice<Bookmark>
 
     fun isBookmarked(contentId: Long, userId: Long): Boolean
+
+    fun deleteByContentIds(contentIds: List<Long>, userId: Long)
 }

--- a/application/src/main/kotlin/com/pokit/category/port/service/CategoryService.kt
+++ b/application/src/main/kotlin/com/pokit/category/port/service/CategoryService.kt
@@ -1,5 +1,6 @@
 package com.pokit.category.port.service
 
+import com.pokit.bookmark.port.out.BookmarkPort
 import com.pokit.category.dto.CategoriesResponse
 import com.pokit.category.dto.CategoryCommand
 import com.pokit.category.dto.DuplicateCategoryCommandV2
@@ -19,6 +20,7 @@ import com.pokit.common.exception.NotFoundCustomException
 import com.pokit.content.port.out.ContentPort
 import com.pokit.user.model.User
 import com.pokit.user.port.out.UserPort
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Slice
 import org.springframework.data.domain.SliceImpl
@@ -33,6 +35,7 @@ class CategoryService(
     private val contentPort: ContentPort,
     private val sharedCategoryPort: SharedCategoryPort,
     private val userPort: UserPort,
+    private val bookmarkPort: BookmarkPort,
 ) : CategoryUseCase {
     companion object {
         private const val MAX_CATEGORY_COUNT = 30
@@ -92,6 +95,11 @@ class CategoryService(
         val category = categoryPort.loadByIdAndUserId(categoryId, userId)
             ?: throw NotFoundCustomException(CategoryErrorCode.NOT_FOUND_CATEGORY)
 
+        val contents = contentPort.loadByUserIdAndCategoryName(category.userId, category.categoryName, PageRequest.of(0, MAX_CATEGORY_COUNT))
+        val contentIds = contents.map { it.contentId }.toMutableList()
+
+        bookmarkPort.deleteByContentIds(contentIds, userId)
+        contentPort.deleteByCategoryId(categoryId)
         categoryPort.delete(category)
     }
 

--- a/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
+++ b/application/src/main/kotlin/com/pokit/content/port/out/ContentPort.kt
@@ -58,4 +58,6 @@ interface ContentPort {
     fun loadAllByKeyword(userId: Long, searchKeywords: List<InterestType>, pageable: Pageable): Slice<ContentsResult>
 
     fun loadById(id: Long): Content?
+
+    fun deleteByCategoryId(categoryId: Long)
 }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #262 

### 📍 리뷰 포인트

- 로직 흐름

### 📝 참고사항(Optional)

- 카테고리 삭제 시 Bookmark, Content 엔티티 삭제상태로 업데이트
- Bookmark, Content 조작 쿼리 추가
