### PR TITLE
[feat #268] 필터에서 유저 조회 시 redis 캐시 활용 

### DIFF
--- a/.github/workflows/api-deploy.yml
+++ b/.github/workflows/api-deploy.yml
@@ -47,6 +47,8 @@ jobs:
           echo "${{ secrets.APPLICATION_CORE }}" > ./application/src/main/resources/application-core.yml
           mkdir -p ./adapters/in-web/src/main/resources
           echo "${{ secrets.APPLICATION_IN_WEB_YML }}" > ./application/src/main/resources/application-in-web.yml
+          mkdir -p ./adapters/out-cache/src/main/resources
+          echo "${{ secrets.APPLICATION_OUT_CACHE_YML }}" > ./adapters/out-cache/src/main/resources/application-out-cache.yml
           mkdir -p ./entry/web/src/main/resources
           echo "${{ secrets.LOGBACK_XML }}" | base64 --decode > ./entry/web/src/main/resources/logback.xml
 

--- a/adapters/in-web/src/main/kotlin/com/pokit/auth/filter/CustomAuthenticationFilter.kt
+++ b/adapters/in-web/src/main/kotlin/com/pokit/auth/filter/CustomAuthenticationFilter.kt
@@ -3,10 +3,8 @@ package com.pokit.auth.filter
 import com.pokit.auth.model.PrincipalUser
 import com.pokit.auth.port.`in`.TokenProvider
 import com.pokit.common.exception.ClientValidationException
-import com.pokit.common.exception.NotFoundCustomException
 import com.pokit.token.exception.AuthErrorCode
-import com.pokit.user.exception.UserErrorCode
-import com.pokit.user.port.out.UserPort
+import com.pokit.user.port.`in`.UserUseCase
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -23,7 +21,7 @@ import org.springframework.web.filter.OncePerRequestFilter
 @Component
 class CustomAuthenticationFilter(
     private val tokenProvider: TokenProvider,
-    private val userPort: UserPort,
+    private val userUseCase: UserUseCase,
 ) : OncePerRequestFilter() {
     override fun shouldNotFilter(request: HttpServletRequest): Boolean {
         val excludePath = arrayOf(
@@ -71,10 +69,7 @@ class CustomAuthenticationFilter(
 
         val token = header.split(" ")[1]
         val userId = tokenProvider.getUserId(token)
-        val user = (
-            userPort.loadById(userId)
-                ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_USER)
-            )
+        val user = userUseCase.getUserInfo(userId)
 
         val principalUser = PrincipalUser.of(user)
         val authorities = listOf(SimpleGrantedAuthority(principalUser.role.description))

--- a/adapters/out-cache/build.gradle.kts
+++ b/adapters/out-cache/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     // 라이브러리
     implementation("org.springframework.boot:spring-boot-starter-data-redis")
+    implementation ("com.google.code.gson:gson:2.10.1")
 
     // 테스팅
     testImplementation("io.kotest.extensions:kotest-extensions-spring:1.1.1")

--- a/adapters/out-cache/src/main/kotlin/com/pokit/config/RedisConfig.kt
+++ b/adapters/out-cache/src/main/kotlin/com/pokit/config/RedisConfig.kt
@@ -1,0 +1,31 @@
+package com.pokit.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig(
+    private val redisProperties: RedisProperties,
+) {
+
+    @Bean
+    fun redisConnectionFactory(): LettuceConnectionFactory {
+        return LettuceConnectionFactory(redisProperties.host, redisProperties.port.toInt())
+    }
+
+    @Bean
+    fun redisTemplate(): RedisTemplate<String, Any> {
+        val template = RedisTemplate<String, Any>()
+        template.setConnectionFactory(redisConnectionFactory())
+
+        val stringSerializer = StringRedisSerializer()
+
+        template.keySerializer = stringSerializer
+        template.valueSerializer = stringSerializer
+
+        return template
+    }
+}

--- a/adapters/out-cache/src/main/kotlin/com/pokit/config/RedisProperties.kt
+++ b/adapters/out-cache/src/main/kotlin/com/pokit/config/RedisProperties.kt
@@ -1,0 +1,11 @@
+package com.pokit.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@ConfigurationProperties(prefix = "spring.data.redis")
+@Configuration
+class RedisProperties {
+    lateinit var host: String
+    lateinit var port: String
+}

--- a/adapters/out-cache/src/main/kotlin/com/pokit/user/impl/UserCacheAdapter.kt
+++ b/adapters/out-cache/src/main/kotlin/com/pokit/user/impl/UserCacheAdapter.kt
@@ -1,0 +1,27 @@
+package com.pokit.user.impl
+
+import com.google.gson.Gson
+import com.pokit.user.model.User
+import com.pokit.user.persist.UserCacheRepository
+import com.pokit.user.port.out.UserCachePort
+import org.springframework.stereotype.Repository
+
+@Repository
+class UserCacheAdapter(
+    private val userCacheRepository: UserCacheRepository,
+) : UserCachePort {
+    override fun persist(user: User) {
+        val jsonUser = Gson().toJson(user)
+        return userCacheRepository.save(user.id, jsonUser)
+    }
+
+    override fun loadById(userId: Long): User? {
+        val findUser = userCacheRepository.findById(userId)
+        val user = findUser?.let { Gson().fromJson(it, User::class.java) }
+        return user
+    }
+
+    override fun deleteById(userId: Long) {
+        userCacheRepository.deleteById(userId)
+    }
+}

--- a/adapters/out-cache/src/main/kotlin/com/pokit/user/persist/UserCacheRepository.kt
+++ b/adapters/out-cache/src/main/kotlin/com/pokit/user/persist/UserCacheRepository.kt
@@ -1,0 +1,28 @@
+package com.pokit.user.persist
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.time.Duration
+
+@Component
+class UserCacheRepository(
+    private val redisTemplate: RedisTemplate<String, Any>,
+) {
+    fun save(userId: Long, user: String) {
+        val key = buildKey(userId)
+        redisTemplate.opsForValue().set(key, user, Duration.ofHours(1)) // TTL 1시간
+    }
+
+    fun findById(userId: Long): String? {
+        val key = buildKey(userId)
+        val user = redisTemplate.opsForValue().get(key) as? String
+        return user
+    }
+
+    fun deleteById(userId: Long) {
+        val key = buildKey(userId)
+        redisTemplate.delete(key)
+    }
+
+    private fun buildKey(userId: Long): String = "user:$userId"
+}

--- a/application/src/main/kotlin/com/pokit/auth/port/service/AuthService.kt
+++ b/application/src/main/kotlin/com/pokit/auth/port/service/AuthService.kt
@@ -15,6 +15,7 @@ import com.pokit.user.dto.UserInfo
 import com.pokit.user.exception.UserErrorCode
 import com.pokit.user.model.Role
 import com.pokit.user.model.User
+import com.pokit.user.port.out.UserCachePort
 import com.pokit.user.port.out.UserPort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -27,6 +28,7 @@ class AuthService(
     private val tokenProvider: TokenProvider,
     private val userPort: UserPort,
     private val contentPort: ContentPort,
+    private val userCachePort: UserCachePort,
 ) : AuthUseCase {
     @Transactional
     override fun signIn(request: SignInRequest): Token {
@@ -51,7 +53,7 @@ class AuthService(
         if (user.authPlatform != request.authPlatform) {
             throw ClientValidationException(AuthErrorCode.INCORRECT_PLATFORM)
         }
-
+        userCachePort.deleteById(user.id)
         contentPort.deleteByUserId(user.id)
         userPort.delete(user)
     }

--- a/application/src/main/kotlin/com/pokit/user/port/out/UserCachePort.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/out/UserCachePort.kt
@@ -1,0 +1,11 @@
+package com.pokit.user.port.out
+
+import com.pokit.user.model.User
+
+interface UserCachePort {
+    fun persist(user: User)
+
+    fun loadById(userId: Long): User?
+
+    fun deleteById(userId: Long)
+}

--- a/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
@@ -19,10 +19,7 @@ import com.pokit.user.model.Interest
 import com.pokit.user.model.InterestType
 import com.pokit.user.model.User
 import com.pokit.user.port.`in`.UserUseCase
-import com.pokit.user.port.out.FcmTokenPort
-import com.pokit.user.port.out.InterestPort
-import com.pokit.user.port.out.UserImagePort
-import com.pokit.user.port.out.UserPort
+import com.pokit.user.port.out.*
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -35,6 +32,7 @@ class UserService(
     private val fcmTokenPort: FcmTokenPort,
     private val userImagePort: UserImagePort,
     private val interestPort: InterestPort,
+    private val userCachePort: UserCachePort,
 ) : UserUseCase {
     companion object {
         private const val UNCATEGORIZED_IMAGE_ID = 1
@@ -116,7 +114,8 @@ class UserService(
     }
 
     override fun getUserInfo(userId: Long): User {
-        return userPort.loadById(userId)
+        return userCachePort.loadById(userId)
+            ?: userPort.loadById(userId)?.also { userCachePort.persist(it) }
             ?: throw NotFoundCustomException(UserErrorCode.NOT_FOUND_USER)
     }
 
@@ -136,6 +135,8 @@ class UserService(
         }
 
         user.modifyProfile(image, command.nickname)
+        userCachePort.deleteById(userId)
+        userCachePort.persist(user)
         return userPort.persist(user)
     }
 

--- a/entry/web/build.gradle.kts
+++ b/entry/web/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
     implementation(project(":adapters:out-persistence"))
     implementation(project(":domain"))
     implementation(project(":adapters:out-web"))
+    implementation(project(":adapters:out-cache"))
 
     // 라이브러리
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/entry/web/src/main/kotlin/com/pokit/WebApplication.kt
+++ b/entry/web/src/main/kotlin/com/pokit/WebApplication.kt
@@ -9,6 +9,6 @@ import org.springframework.boot.runApplication
 class WebApplication
 
 fun main(args: Array<String>) {
-    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-web")
+    System.setProperty("spring.config.name", "application-out-web, application-core, application-out-persistence, application-in-web, application-out-cache")
     runApplication<WebApplication>(*args)
 }


### PR DESCRIPTION
### ⛏ 이슈 번호

close #268 

### 📍 리뷰 포인트

- redis 활용 전략 (갱신 시점, 삭제 시점)
- 만료시간 (재검토 필요)
- out-cache 모듈 적용에 따른 구조 유지성
- 키 밸류 형태

### 📝 참고사항(Optional)

- application-out-cache.yml 추가
- docker-compose redis 컨테이너 추가
