### PR TITLE
[fix #275] 회원가입 후 메인화면 진입 시 오류 문제 해결

### DIFF
--- a/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
+++ b/application/src/main/kotlin/com/pokit/user/port/service/UserService.kt
@@ -63,7 +63,7 @@ class UserService(
         )
         categoryPort.persist(category)
 
-        Category(
+        val favoriteCategory = Category(
             userId = savedUser.id,
             categoryName = FAVORITE.displayName,
             categoryImage = image,
@@ -73,6 +73,7 @@ class UserService(
             isFavorite = true
         )
         categoryPort.persist(category)
+        categoryPort.persist(favoriteCategory)
 
         request.interests.forEach {
             interestPort.persist(


### PR DESCRIPTION
### ⛏ 이슈 번호

close #275 

### 📝 참고사항(Optional)

- 메인화면에서 즐겨찾기 포킷을 조회하는데 null이라 NPE 발생
- 회원가입 시 즐겨찾기 포킷을 자동 저장
